### PR TITLE
Add spectral kurtosis metrics and corrmap template matching for ICA

### DIFF
--- a/src/custom/preprocessing/auto_ica.py
+++ b/src/custom/preprocessing/auto_ica.py
@@ -50,6 +50,7 @@ Author: Harrison Ritz, 2025
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
 
@@ -74,6 +75,7 @@ class AutoICAAnalysis(BaseAnalysis):
     Uses multiple strategies to identify artifact components:
     - Reference sensor correlation (if ref_bads=True)
     - GESD outlier detection on kurtosis/variance (if gesd_bads=True)
+    - Spatial template matching via corrmap (if corrmap_bads=True)
 
     Components identified by any method are added to ica.exclude
     and will be removed when ICA is applied to the data.
@@ -236,6 +238,10 @@ class AutoICAAnalysis(BaseAnalysis):
         if getattr(self.cfg, "gesd_bads", True):
             ica = self._label_by_gesd_new(ica, raw)
 
+        # Spatial template matching via corrmap
+        if getattr(self.cfg, "corrmap_bads", False):
+            ica = self._label_by_corrmap(ica, raw)
+
         # Remove duplicates from exclude list
         ica.exclude = sorted(set(ica.exclude))
 
@@ -291,6 +297,209 @@ class AutoICAAnalysis(BaseAnalysis):
 
         # Cleanup
         del ref_raw, ref_ica, ref_src
+
+        return ica
+
+    def _label_by_corrmap(
+        self, ica: mne.preprocessing.ICA, raw: mne.io.BaseRaw
+    ) -> mne.preprocessing.ICA:
+        """Identify bad components by matching against pre-computed spatial templates.
+
+        Loads topographic templates (ICA mixing-matrix columns) from a directory
+        of ``.npy`` files and uses ``mne.preprocessing.corrmap`` to find ICA
+        components whose spatial patterns correlate with each template.  This is
+        useful for detecting EOG / ECG artifacts when no physiological reference
+        channel is available.
+
+        Template directory layout::
+
+            <corrmap_template_dir>/
+                reference_channels.npy   # 1-D array of channel-name strings
+                eog_01.npy               # topography for EOG template 1
+                eog_02.npy               # topography for EOG template 2
+                ecg_01.npy               # topography for ECG template 1
+                ...
+
+        Channel alignment
+        -----------------
+        Templates are defined on a *reference* channel set stored in
+        ``reference_channels.npy``.  The current ICA may have a different
+        (usually smaller) channel set due to sensor dropout.  For each template,
+        a per-channel lookup maps reference values onto the ICA's channel order;
+        channels in the ICA that are absent from the reference get a template
+        weight of 0 and are effectively ignored in the correlation.
+
+        Configuration attributes
+        ------------------------
+        corrmap_bads : bool
+            Master enable switch (default ``False``).
+        corrmap_template_dir : str
+            Path to the template directory.
+        corrmap_eog : bool
+            Use EOG templates (default ``True``).
+        corrmap_ecg : bool
+            Use ECG templates (default ``True``).
+        n_eog_templates : int
+            Number of EOG templates to use, in alphabetical order (default 3).
+        n_ecg_templates : int
+            Number of ECG templates to use, in alphabetical order (default 3).
+        corrmap_threshold : float | 'auto'
+            Correlation threshold passed to corrmap (default ``'auto'``).
+
+        Parameters
+        ----------
+        ica : mne.preprocessing.ICA
+            ICA solution.
+        raw : mne.io.BaseRaw
+            Raw data (used for channel-type metadata).
+
+        Returns
+        -------
+        ica : mne.preprocessing.ICA
+            ICA with matched components added to ``ica.exclude`` and
+            ``ica.labels_``.
+        """
+        self.log("Identifying bad components using corrmap template matching...")
+
+        # --- Validate template directory ---
+        template_dir_str = getattr(self.cfg, "corrmap_template_dir", "")
+        if not template_dir_str:
+            self.log("corrmap_template_dir not set; skipping")
+            return ica
+
+        template_dir = Path(template_dir_str)
+        if not template_dir.is_dir():
+            self.log(f"Template directory not found: {template_dir}; skipping")
+            return ica
+
+        # --- Load reference channel list ---
+        ref_channels_path = template_dir / "reference_channels.npy"
+        if not ref_channels_path.exists():
+            self.log(
+                f"reference_channels.npy not found in {template_dir}; skipping"
+            )
+            return ica
+
+        ref_channels = np.load(str(ref_channels_path), allow_pickle=True).tolist()
+        ref_channel_to_idx = {name: i for i, name in enumerate(ref_channels)}
+
+        # --- Report channel alignment ---
+        ica_channels = ica.ch_names
+        n_shared = sum(1 for ch in ica_channels if ch in ref_channel_to_idx)
+        n_total = len(ica_channels)
+        self.log(
+            f"Channel alignment: {n_shared}/{n_total} ICA channels "
+            f"found in reference set ({len(ref_channels)} channels)"
+        )
+        if n_shared < 0.9 * n_total:
+            self.log(
+                f"Warning: only {n_shared}/{n_total} ICA channels are in the "
+                "reference set — template matching may be unreliable."
+            )
+
+        # --- Determine which artifact types and how many templates to use ---
+        threshold = getattr(self.cfg, "corrmap_threshold", "auto")
+        ch_type = (
+            self.cfg.ch_types[0]
+            if hasattr(self.cfg, "ch_types") and self.cfg.ch_types
+            else "mag"
+        )
+
+        type_configs = []
+        if getattr(self.cfg, "corrmap_eog", True):
+            n_eog = getattr(self.cfg, "n_eog_templates", 3)
+            if n_eog > 0:
+                type_configs.append(("eog", n_eog))
+        if getattr(self.cfg, "corrmap_ecg", True):
+            n_ecg = getattr(self.cfg, "n_ecg_templates", 3)
+            if n_ecg > 0:
+                type_configs.append(("ecg", n_ecg))
+
+        if not type_configs:
+            self.log("No artifact types enabled for corrmap; skipping")
+            return ica
+
+        # --- Run corrmap for each artifact type ---
+        for artifact_type, n_templates in type_configs:
+            template_files = sorted(
+                template_dir.glob(f"{artifact_type}_*.npy")
+            )[:n_templates]
+
+            if not template_files:
+                self.log(
+                    f"No {artifact_type} templates found "
+                    f"(pattern: {artifact_type}_*.npy); skipping"
+                )
+                continue
+
+            self.log(
+                f"Running corrmap: {len(template_files)} "
+                f"{artifact_type} template(s), threshold={threshold!r}"
+            )
+
+            # Accumulate matched indices across all templates for this type.
+            # Each corrmap call may overwrite ica.labels_[artifact_type], so we
+            # collect the union manually.
+            accumulated_idx: set[int] = set(ica.labels_.get(artifact_type, []))
+
+            for template_path in template_files:
+                template_ref = np.load(str(template_path))  # (n_ref_channels,)
+
+                # Align template to ICA channel order.
+                # For channels not in the reference, weight = 0 (ignored).
+                template_aligned = np.array(
+                    [
+                        template_ref[ref_channel_to_idx[ch]]
+                        if ch in ref_channel_to_idx
+                        else 0.0
+                        for ch in ica_channels
+                    ],
+                    dtype=float,
+                )
+
+                # Clear the label so we can detect only the new matches from
+                # this template call.
+                ica.labels_.pop(artifact_type, None)
+
+                try:
+                    mne.preprocessing.corrmap(
+                        [ica],
+                        template=template_aligned,
+                        label=artifact_type,
+                        threshold=threshold,
+                        ch_type=ch_type,
+                        plot=False,
+                        show=False,
+                        verbose=False,
+                    )
+                except Exception as exc:
+                    self.log(
+                        f"  {template_path.name}: corrmap raised {type(exc).__name__}"
+                        f"({exc}); skipping this template"
+                    )
+                    continue
+
+                newly_matched = set(ica.labels_.get(artifact_type, []))
+                new_finds = newly_matched - accumulated_idx
+                accumulated_idx |= newly_matched
+
+                self.log(
+                    f"  {template_path.name}: "
+                    + (
+                        f"{len(new_finds)} new → {sorted(new_finds)}"
+                        if new_finds
+                        else "no new matches"
+                    )
+                )
+
+            # Write back accumulated labels and extend exclude list.
+            final_idx = sorted(accumulated_idx)
+            ica.labels_[artifact_type] = final_idx
+            if final_idx:
+                self.log(f"{artifact_type}: adding components {final_idx} to exclude")
+                ica.exclude.extend(final_idx)
+            else:
+                self.log(f"{artifact_type}: no components matched")
 
         return ica
 

--- a/src/custom/preprocessing/auto_ica.py
+++ b/src/custom/preprocessing/auto_ica.py
@@ -335,14 +335,12 @@ class AutoICAAnalysis(BaseAnalysis):
             Master enable switch (default ``False``).
         _corrmap_template_dir : str
             Path to the template directory.
-        _corrmap_eog : bool
-            Use EOG templates (default ``True``).
-        _corrmap_ecg : bool
-            Use ECG templates (default ``True``).
         _n_eog_templates : int
-            Number of EOG templates to use, in alphabetical order (default 3).
+            Number of EOG templates to use, in alphabetical order. Set to 0
+            to skip EOG matching entirely (default 3).
         _n_ecg_templates : int
-            Number of ECG templates to use, in alphabetical order (default 3).
+            Number of ECG templates to use, in alphabetical order. Set to 0
+            to skip ECG matching entirely (default 3).
         _corrmap_threshold : float | 'auto'
             Correlation threshold passed to corrmap (default ``'auto'``).
 
@@ -406,14 +404,12 @@ class AutoICAAnalysis(BaseAnalysis):
         )
 
         type_configs = []
-        if getattr(self.cfg, "_corrmap_eog", True):
-            n_eog = getattr(self.cfg, "_n_eog_templates", 3)
-            if n_eog > 0:
-                type_configs.append(("eog", n_eog))
-        if getattr(self.cfg, "_corrmap_ecg", True):
-            n_ecg = getattr(self.cfg, "_n_ecg_templates", 3)
-            if n_ecg > 0:
-                type_configs.append(("ecg", n_ecg))
+        n_eog = getattr(self.cfg, "_n_eog_templates", 3)
+        if n_eog > 0:
+            type_configs.append(("eog", n_eog))
+        n_ecg = getattr(self.cfg, "_n_ecg_templates", 3)
+        if n_ecg > 0:
+            type_configs.append(("ecg", n_ecg))
 
         if not type_configs:
             self.log("No artifact types enabled for corrmap; skipping")

--- a/src/custom/preprocessing/auto_ica.py
+++ b/src/custom/preprocessing/auto_ica.py
@@ -75,7 +75,7 @@ class AutoICAAnalysis(BaseAnalysis):
     Uses multiple strategies to identify artifact components:
     - Reference sensor correlation (if ref_bads=True)
     - GESD outlier detection on kurtosis/variance (if gesd_bads=True)
-    - Spatial template matching via corrmap (if corrmap_bads=True)
+    - Spatial template matching via corrmap (if _corrmap_bads=True)
 
     Components identified by any method are added to ica.exclude
     and will be removed when ICA is applied to the data.
@@ -239,7 +239,7 @@ class AutoICAAnalysis(BaseAnalysis):
             ica = self._label_by_gesd_new(ica, raw)
 
         # Spatial template matching via corrmap
-        if getattr(self.cfg, "corrmap_bads", False):
+        if getattr(self.cfg, "_corrmap_bads", False):
             ica = self._label_by_corrmap(ica, raw)
 
         # Remove duplicates from exclude list
@@ -313,7 +313,7 @@ class AutoICAAnalysis(BaseAnalysis):
 
         Template directory layout::
 
-            <corrmap_template_dir>/
+            <_corrmap_template_dir>/
                 reference_channels.npy   # 1-D array of channel-name strings
                 eog_01.npy               # topography for EOG template 1
                 eog_02.npy               # topography for EOG template 2
@@ -331,19 +331,19 @@ class AutoICAAnalysis(BaseAnalysis):
 
         Configuration attributes
         ------------------------
-        corrmap_bads : bool
+        _corrmap_bads : bool
             Master enable switch (default ``False``).
-        corrmap_template_dir : str
+        _corrmap_template_dir : str
             Path to the template directory.
-        corrmap_eog : bool
+        _corrmap_eog : bool
             Use EOG templates (default ``True``).
-        corrmap_ecg : bool
+        _corrmap_ecg : bool
             Use ECG templates (default ``True``).
-        n_eog_templates : int
+        _n_eog_templates : int
             Number of EOG templates to use, in alphabetical order (default 3).
-        n_ecg_templates : int
+        _n_ecg_templates : int
             Number of ECG templates to use, in alphabetical order (default 3).
-        corrmap_threshold : float | 'auto'
+        _corrmap_threshold : float | 'auto'
             Correlation threshold passed to corrmap (default ``'auto'``).
 
         Parameters
@@ -362,9 +362,9 @@ class AutoICAAnalysis(BaseAnalysis):
         self.log("Identifying bad components using corrmap template matching...")
 
         # --- Validate template directory ---
-        template_dir_str = getattr(self.cfg, "corrmap_template_dir", "")
+        template_dir_str = getattr(self.cfg, "_corrmap_template_dir", "")
         if not template_dir_str:
-            self.log("corrmap_template_dir not set; skipping")
+            self.log("_corrmap_template_dir not set; skipping")
             return ica
 
         template_dir = Path(template_dir_str)
@@ -398,7 +398,7 @@ class AutoICAAnalysis(BaseAnalysis):
             )
 
         # --- Determine which artifact types and how many templates to use ---
-        threshold = getattr(self.cfg, "corrmap_threshold", "auto")
+        threshold = getattr(self.cfg, "_corrmap_threshold", "auto")
         ch_type = (
             self.cfg.ch_types[0]
             if hasattr(self.cfg, "ch_types") and self.cfg.ch_types
@@ -406,12 +406,12 @@ class AutoICAAnalysis(BaseAnalysis):
         )
 
         type_configs = []
-        if getattr(self.cfg, "corrmap_eog", True):
-            n_eog = getattr(self.cfg, "n_eog_templates", 3)
+        if getattr(self.cfg, "_corrmap_eog", True):
+            n_eog = getattr(self.cfg, "_n_eog_templates", 3)
             if n_eog > 0:
                 type_configs.append(("eog", n_eog))
-        if getattr(self.cfg, "corrmap_ecg", True):
-            n_ecg = getattr(self.cfg, "n_ecg_templates", 3)
+        if getattr(self.cfg, "_corrmap_ecg", True):
+            n_ecg = getattr(self.cfg, "_n_ecg_templates", 3)
             if n_ecg > 0:
                 type_configs.append(("ecg", n_ecg))
 

--- a/src/custom/preprocessing/auto_ica.py
+++ b/src/custom/preprocessing/auto_ica.py
@@ -588,14 +588,34 @@ class AutoICAAnalysis(BaseAnalysis):
         autocorr_denom = np.sum(s_centered**2, axis=1)
         autocorr_1lag = autocorr_num / autocorr_denom
 
-        # Spectral slope
+        # Spectral slope, derivative, and residual metrics
         nperseg = min(n_times, int(2 * sfreq))
         freqs, psd = welch(sources, sfreq, nperseg=nperseg, axis=1)
+
+        # --- Spectral derivative kurtosis (all Welch frequencies) ---
+        # d(log_psd)/df: fractional change in power per Hz.
+        # A boxcar artifact creates two sharp steps (onset/offset) → heavy-tailed
+        # derivative distribution → high kurtosis.
+        df = freqs[1] - freqs[0]  # uniform frequency spacing from Welch
+        log_psd_all = np.log10(psd + 1e-20)  # (n_components, n_freqs)
+        spectral_deriv = np.diff(log_psd_all, axis=1) / df  # (n_components, n_freqs-1)
+        spectral_deriv_kurtosis = kurtosis(spectral_deriv, axis=1, fisher=True)
+
+        # --- Spectral slope and residual kurtosis (fmin-fmax band) ---
+        # Fit a power-law (1/f^n) baseline in log-log space, then take the
+        # kurtosis of the residuals. Narrow-band artifacts create a concentrated
+        # bump above the baseline → high residual kurtosis.
         freq_mask = (freqs >= fmin) & (freqs <= fmax)
         log_freqs = np.log10(freqs[freq_mask])
         log_psd = np.log10(psd[:, freq_mask] + 1e-20)
         X = np.column_stack([log_freqs, np.ones_like(log_freqs)])
-        spectral_slope = np.linalg.lstsq(X, log_psd.T, rcond=None)[0][0]
+        coeffs = np.linalg.lstsq(X, log_psd.T, rcond=None)[0]  # (2, n_components)
+        spectral_slope = coeffs[0]  # (n_components,)
+
+        # Residuals: how much each frequency deviates from the 1/f baseline
+        log_psd_fit = (X @ coeffs).T  # (n_components, n_freqs_masked)
+        residuals = log_psd - log_psd_fit  # (n_components, n_freqs_masked)
+        spectral_resid_kurtosis = kurtosis(residuals, axis=1, fisher=True)
 
         # Spatial kurtosis
         spatial_kurt = kurtosis(topos, axis=0, fisher=True)
@@ -608,6 +628,8 @@ class AutoICAAnalysis(BaseAnalysis):
             "autocorr_1lag": autocorr_1lag,
             "spectral_slope": spectral_slope,
             "spatial_kurtosis": spatial_kurt,
+            "spectral_deriv_kurtosis": spectral_deriv_kurtosis,
+            "spectral_resid_kurtosis": spectral_resid_kurtosis,
         }
 
     def _prepare_metrics_for_gesd(self, diagnostics: dict) -> list:
@@ -655,6 +677,21 @@ class AutoICAAnalysis(BaseAnalysis):
         spatial_kurt = diagnostics["spatial_kurtosis"]
         signed_sqrt_spatial = np.sign(spatial_kurt) * np.sqrt(np.abs(spatial_kurt) + 1e-10)
         metrics.append(("spatial_kurtosis_sqrt", signed_sqrt_spatial, 1))
+
+        # 6. Spectral derivative kurtosis: high = sharp narrow-band transitions.
+        # d(log_psd)/df has heavy tails when the spectrum has sudden onset/offset
+        # edges (boxcar-like artifact). Natural 1/f spectra are smooth → low kurtosis.
+        spec_deriv_kurt = diagnostics["spectral_deriv_kurtosis"]
+        signed_sqrt_spec_deriv = np.sign(spec_deriv_kurt) * np.sqrt(np.abs(spec_deriv_kurt) + 1e-10)
+        metrics.append(("spectral_deriv_kurtosis_sqrt", signed_sqrt_spec_deriv, 1))
+
+        # 7. Spectral residual kurtosis: high = concentrated deviation from 1/f.
+        # Residuals from the power-law fit are near-Gaussian for typical brain ICs.
+        # A narrow-band artifact creates a localized bump above the baseline
+        # → heavy-tailed residuals → high kurtosis.
+        spec_resid_kurt = diagnostics["spectral_resid_kurtosis"]
+        signed_sqrt_spec_resid = np.sign(spec_resid_kurt) * np.sqrt(np.abs(spec_resid_kurt) + 1e-10)
+        metrics.append(("spectral_resid_kurtosis_sqrt", signed_sqrt_spec_resid, 1))
 
         return metrics
 

--- a/tests/test_auto_ica.py
+++ b/tests/test_auto_ica.py
@@ -346,10 +346,10 @@ class TestLabelByCorrmap:
     # ---- graceful-skip cases ------------------------------------------------
 
     def test_skips_when_no_template_dir_set(self, ica_cfg, synthetic_ica_and_raw):
-        """Returns ICA unchanged when corrmap_template_dir is not configured."""
+        """Returns ICA unchanged when _corrmap_template_dir is not configured."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
-        # corrmap_template_dir deliberately NOT set
+        # _corrmap_template_dir deliberately NOT set
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -358,7 +358,7 @@ class TestLabelByCorrmap:
         """Returns ICA unchanged when the template directory does not exist."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path / "nonexistent")
+        ica_cfg._corrmap_template_dir = str(tmp_path / "nonexistent")
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -369,7 +369,7 @@ class TestLabelByCorrmap:
         """Returns ICA unchanged when reference_channels.npy is absent."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)  # dir exists but no .npy
+        ica_cfg._corrmap_template_dir = str(tmp_path)  # dir exists but no .npy
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -381,10 +381,10 @@ class TestLabelByCorrmap:
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
         np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.n_eog_templates = 3
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_eog_templates = 3
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -392,13 +392,13 @@ class TestLabelByCorrmap:
     def test_skips_when_both_types_disabled(
         self, ica_cfg, synthetic_ica_and_raw, tmp_path
     ):
-        """Returns ICA unchanged when both corrmap_eog and corrmap_ecg are False."""
+        """Returns ICA unchanged when both _corrmap_eog and _corrmap_ecg are False."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
         np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.corrmap_eog = False
-        ica_cfg.corrmap_ecg = False
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._corrmap_eog = False
+        ica_cfg._corrmap_ecg = False
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -418,11 +418,11 @@ class TestLabelByCorrmap:
         np.save(str(tmp_path / "eog_01.npy"), target_topo)
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 1
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.corrmap_threshold = 0.9  # high threshold: only near-exact match
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 1
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._corrmap_threshold = 0.9  # high threshold: only near-exact match
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -445,12 +445,12 @@ class TestLabelByCorrmap:
         np.save(str(tmp_path / "ecg_01.npy"), target_topo)
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 0
-        ica_cfg.n_ecg_templates = 1
-        ica_cfg.corrmap_eog = False
-        ica_cfg.corrmap_ecg = True
-        ica_cfg.corrmap_threshold = 0.9
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 0
+        ica_cfg._n_ecg_templates = 1
+        ica_cfg._corrmap_eog = False
+        ica_cfg._corrmap_ecg = True
+        ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -468,11 +468,11 @@ class TestLabelByCorrmap:
         np.save(str(tmp_path / "eog_01.npy"), components[:, 0])
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 1
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.corrmap_threshold = 0.9
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 1
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -492,11 +492,11 @@ class TestLabelByCorrmap:
         np.save(str(tmp_path / "eog_02.npy"), components[:, 1])
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 2
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.corrmap_threshold = 0.9
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 2
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -528,11 +528,11 @@ class TestLabelByCorrmap:
         np.save(str(tmp_path / "eog_01.npy"), full_template)
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 1
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.corrmap_threshold = 0.9
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 1
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -544,21 +544,21 @@ class TestLabelByCorrmap:
     def test_n_templates_limits_files_used(
         self, ica_cfg, synthetic_ica_and_raw, tmp_path
     ):
-        """n_eog_templates=1 should only use the first template file."""
+        """_n_eog_templates=1 should only use the first template file."""
         ica, raw = synthetic_ica_and_raw
         components = ica.get_components()
         np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
         # Template 1 targets component 0 (will be used)
         np.save(str(tmp_path / "eog_01.npy"), components[:, 0])
-        # Template 2 targets component 1 (should be ignored when n_eog_templates=1)
+        # Template 2 targets component 1 (should be ignored when _n_eog_templates=1)
         np.save(str(tmp_path / "eog_02.npy"), components[:, 1])
 
         ica.exclude = []
-        ica_cfg.corrmap_template_dir = str(tmp_path)
-        ica_cfg.n_eog_templates = 1  # only use first
-        ica_cfg.corrmap_eog = True
-        ica_cfg.corrmap_ecg = False
-        ica_cfg.corrmap_threshold = 0.9
+        ica_cfg._corrmap_template_dir = str(tmp_path)
+        ica_cfg._n_eog_templates = 1  # only use first
+        ica_cfg._corrmap_eog = True
+        ica_cfg._corrmap_ecg = False
+        ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
@@ -568,17 +568,17 @@ class TestLabelByCorrmap:
 
     # ---- integration --------------------------------------------------------
 
-    def test_corrmap_bads_wired_into_auto_ica(
+    def test__corrmap_bads_wired_into_auto_ica(
         self, ica_cfg, synthetic_ica_and_raw, tmp_path
     ):
-        """corrmap_bads=True calls _label_by_corrmap inside _auto_ica."""
+        """_corrmap_bads=True calls _label_by_corrmap inside _auto_ica."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
         ica_cfg.ref_bads = False
         ica_cfg.gesd_bads = False
-        ica_cfg.corrmap_bads = True
+        ica_cfg._corrmap_bads = True
         # Point at a dir with no reference_channels.npy → graceful skip
-        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg._corrmap_template_dir = str(tmp_path)
 
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._auto_ica(ica, raw)

--- a/tests/test_auto_ica.py
+++ b/tests/test_auto_ica.py
@@ -382,9 +382,8 @@ class TestLabelByCorrmap:
         ica.exclude = []
         np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
         ica_cfg._corrmap_template_dir = str(tmp_path)
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
         ica_cfg._n_eog_templates = 3
+        ica_cfg._n_ecg_templates = 0
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -392,13 +391,13 @@ class TestLabelByCorrmap:
     def test_skips_when_both_types_disabled(
         self, ica_cfg, synthetic_ica_and_raw, tmp_path
     ):
-        """Returns ICA unchanged when both _corrmap_eog and _corrmap_ecg are False."""
+        """Returns ICA unchanged when _n_eog_templates and _n_ecg_templates are both 0."""
         ica, raw = synthetic_ica_and_raw
         ica.exclude = []
         np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
         ica_cfg._corrmap_template_dir = str(tmp_path)
-        ica_cfg._corrmap_eog = False
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_eog_templates = 0
+        ica_cfg._n_ecg_templates = 0
         analysis = AutoICAAnalysis(ica_cfg)
         result = analysis._label_by_corrmap(ica, raw)
         assert result.exclude == []
@@ -420,8 +419,7 @@ class TestLabelByCorrmap:
         ica.exclude = []
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 1
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_ecg_templates = 0
         ica_cfg._corrmap_threshold = 0.9  # high threshold: only near-exact match
 
         analysis = AutoICAAnalysis(ica_cfg)
@@ -448,8 +446,6 @@ class TestLabelByCorrmap:
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 0
         ica_cfg._n_ecg_templates = 1
-        ica_cfg._corrmap_eog = False
-        ica_cfg._corrmap_ecg = True
         ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
@@ -470,8 +466,7 @@ class TestLabelByCorrmap:
         ica.exclude = []
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 1
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_ecg_templates = 0
         ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
@@ -494,8 +489,7 @@ class TestLabelByCorrmap:
         ica.exclude = []
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 2
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_ecg_templates = 0
         ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
@@ -530,8 +524,7 @@ class TestLabelByCorrmap:
         ica.exclude = []
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 1
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_ecg_templates = 0
         ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)
@@ -556,8 +549,7 @@ class TestLabelByCorrmap:
         ica.exclude = []
         ica_cfg._corrmap_template_dir = str(tmp_path)
         ica_cfg._n_eog_templates = 1  # only use first
-        ica_cfg._corrmap_eog = True
-        ica_cfg._corrmap_ecg = False
+        ica_cfg._n_ecg_templates = 0
         ica_cfg._corrmap_threshold = 0.9
 
         analysis = AutoICAAnalysis(ica_cfg)

--- a/tests/test_auto_ica.py
+++ b/tests/test_auto_ica.py
@@ -337,6 +337,258 @@ class TestLabelByGESDNew:
 
 
 # ---------------------------------------------------------------------------
+# _label_by_corrmap (spatial template matching)
+# ---------------------------------------------------------------------------
+
+class TestLabelByCorrmap:
+    """Tests for _label_by_corrmap template matching via corrmap."""
+
+    # ---- graceful-skip cases ------------------------------------------------
+
+    def test_skips_when_no_template_dir_set(self, ica_cfg, synthetic_ica_and_raw):
+        """Returns ICA unchanged when corrmap_template_dir is not configured."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        # corrmap_template_dir deliberately NOT set
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+        assert result.exclude == []
+
+    def test_skips_when_dir_missing(self, ica_cfg, synthetic_ica_and_raw, tmp_path):
+        """Returns ICA unchanged when the template directory does not exist."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path / "nonexistent")
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+        assert result.exclude == []
+
+    def test_skips_when_reference_channels_missing(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Returns ICA unchanged when reference_channels.npy is absent."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)  # dir exists but no .npy
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+        assert result.exclude == []
+
+    def test_skips_when_no_template_files_match(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Skips gracefully when no eog_*.npy / ecg_*.npy files are found."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.n_eog_templates = 3
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+        assert result.exclude == []
+
+    def test_skips_when_both_types_disabled(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Returns ICA unchanged when both corrmap_eog and corrmap_ecg are False."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.corrmap_eog = False
+        ica_cfg.corrmap_ecg = False
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+        assert result.exclude == []
+
+    # ---- detection tests ----------------------------------------------------
+
+    def test_detects_eog_matching_component(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """A template built from an ICA component's own topography must be found."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()  # (n_channels, n_components)
+        target_idx = 0
+        target_topo = components[:, target_idx]
+
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        np.save(str(tmp_path / "eog_01.npy"), target_topo)
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 1
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.corrmap_threshold = 0.9  # high threshold: only near-exact match
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        assert target_idx in result.exclude, (
+            f"Expected component {target_idx} in exclude, got {result.exclude}"
+        )
+        assert target_idx in result.labels_.get("eog", [])
+
+    def test_detects_ecg_matching_component(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """ECG template matching works the same way as EOG."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()
+        target_idx = 1
+        target_topo = components[:, target_idx]
+
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        np.save(str(tmp_path / "ecg_01.npy"), target_topo)
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 0
+        ica_cfg.n_ecg_templates = 1
+        ica_cfg.corrmap_eog = False
+        ica_cfg.corrmap_ecg = True
+        ica_cfg.corrmap_threshold = 0.9
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        assert target_idx in result.exclude
+        assert target_idx in result.labels_.get("ecg", [])
+
+    def test_labels_and_exclude_are_consistent(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Every component in ica.labels_['eog'] must also appear in ica.exclude."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        np.save(str(tmp_path / "eog_01.npy"), components[:, 0])
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 1
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.corrmap_threshold = 0.9
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        for idx in result.labels_.get("eog", []):
+            assert idx in result.exclude
+
+    def test_multiple_templates_accumulate(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Matches from multiple templates of the same type are unioned, not overwritten."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        # Two templates targeting different components
+        np.save(str(tmp_path / "eog_01.npy"), components[:, 0])
+        np.save(str(tmp_path / "eog_02.npy"), components[:, 1])
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 2
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.corrmap_threshold = 0.9
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        # Both targets should be matched
+        assert 0 in result.exclude
+        assert 1 in result.exclude
+
+    # ---- channel alignment --------------------------------------------------
+
+    def test_channel_subset_alignment(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """Reference with extra channels aligns correctly to the ICA's subset."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()
+        target_topo = components[:, 0]
+
+        # Reference = ICA channels + 5 phantom channels not in the ICA
+        ica_channels = list(ica.ch_names)
+        extra_channels = [f"EXTRA{i:03d}" for i in range(5)]
+        ref_channels = np.array(ica_channels + extra_channels)
+
+        # Template has values for all reference channels; extras are noise
+        rng = np.random.RandomState(42)
+        full_template = np.concatenate([target_topo, rng.randn(5) * 0.01])
+
+        np.save(str(tmp_path / "reference_channels.npy"), ref_channels)
+        np.save(str(tmp_path / "eog_01.npy"), full_template)
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 1
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.corrmap_threshold = 0.9
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        # Should not crash, and should still identify the target component
+        assert isinstance(result, mne.preprocessing.ICA)
+        assert 0 in result.exclude
+
+    def test_n_templates_limits_files_used(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """n_eog_templates=1 should only use the first template file."""
+        ica, raw = synthetic_ica_and_raw
+        components = ica.get_components()
+        np.save(str(tmp_path / "reference_channels.npy"), np.array(ica.ch_names))
+        # Template 1 targets component 0 (will be used)
+        np.save(str(tmp_path / "eog_01.npy"), components[:, 0])
+        # Template 2 targets component 1 (should be ignored when n_eog_templates=1)
+        np.save(str(tmp_path / "eog_02.npy"), components[:, 1])
+
+        ica.exclude = []
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+        ica_cfg.n_eog_templates = 1  # only use first
+        ica_cfg.corrmap_eog = True
+        ica_cfg.corrmap_ecg = False
+        ica_cfg.corrmap_threshold = 0.9
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._label_by_corrmap(ica, raw)
+
+        assert 0 in result.exclude        # component from template 1
+        assert 1 not in result.exclude    # component from template 2 (ignored)
+
+    # ---- integration --------------------------------------------------------
+
+    def test_corrmap_bads_wired_into_auto_ica(
+        self, ica_cfg, synthetic_ica_and_raw, tmp_path
+    ):
+        """corrmap_bads=True calls _label_by_corrmap inside _auto_ica."""
+        ica, raw = synthetic_ica_and_raw
+        ica.exclude = []
+        ica_cfg.ref_bads = False
+        ica_cfg.gesd_bads = False
+        ica_cfg.corrmap_bads = True
+        # Point at a dir with no reference_channels.npy → graceful skip
+        ica_cfg.corrmap_template_dir = str(tmp_path)
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        result = analysis._auto_ica(ica, raw)
+
+        # Should complete without error (skips due to missing reference file)
+        assert isinstance(result, mne.preprocessing.ICA)
+        assert result.exclude == []
+
+
+# ---------------------------------------------------------------------------
 # _auto_ica integration
 # ---------------------------------------------------------------------------
 

--- a/tests/test_auto_ica.py
+++ b/tests/test_auto_ica.py
@@ -106,6 +106,8 @@ class TestICAComponentDiagnostics:
             "autocorr_1lag",
             "spectral_slope",
             "spatial_kurtosis",
+            "spectral_deriv_kurtosis",
+            "spectral_resid_kurtosis",
         }
         assert set(diag.keys()) == expected_keys
 
@@ -140,6 +142,67 @@ class TestICAComponentDiagnostics:
         diag = analysis._ica_component_diagnostics(ica, raw)
         assert np.all(diag["hf_ratio"] > 0)
 
+    def test_spectral_deriv_kurtosis_higher_for_narrow_band(self, ica_cfg):
+        """Narrow-band artifact should produce higher spectral derivative kurtosis.
+
+        A synthetic component with a boxcar power spectrum (sharp onset/offset at
+        a narrow band) should yield higher d(log_psd)/df kurtosis than a broadband
+        component with a smooth 1/f-like spectrum.
+        """
+        rng = np.random.RandomState(0)
+        n_ch = 20
+        sfreq = 300.0
+        n_times = int(sfreq * 10)  # 10 s for stable spectral estimates
+
+        # --- Broadband 1/f-like component ---
+        # Filter white noise through a 1/f filter in frequency domain
+        freqs_template = np.fft.rfftfreq(n_times, 1 / sfreq)
+        freqs_template[0] = 1.0  # avoid divide-by-zero at DC
+        amplitude = 1.0 / freqs_template  # 1/f amplitude
+        phase = rng.uniform(0, 2 * np.pi, size=len(freqs_template))
+        spectrum = amplitude * np.exp(1j * phase)
+        broadband = np.fft.irfft(spectrum, n=n_times)  # (n_times,)
+
+        # --- Narrow-band artifact: sinusoid at 20 Hz + low-amplitude broadband ---
+        t = np.arange(n_times) / sfreq
+        narrowband = np.sin(2 * np.pi * 20 * t) + 0.05 * rng.randn(n_times)
+
+        # Package as two-component ICA source matrix (n_components, n_times)
+        # We bypass fitting ICA by mocking the source extraction
+        sources = np.vstack([broadband, narrowband])
+        sources = sources / sources.std(axis=1, keepdims=True)  # normalize
+
+        # Build a minimal Raw + ICA mock so _ica_component_diagnostics can run
+        info = mne.create_info(
+            [f"MEG{i:03d}" for i in range(n_ch)], sfreq, ["mag"] * n_ch
+        )
+        data = rng.randn(n_ch, n_times) * 1e-13
+        raw = mne.io.RawArray(data, info)
+
+        ica = mne.preprocessing.ICA(n_components=2, method="fastica", random_state=0, max_iter=200)
+        ica.fit(raw)
+
+        # Monkey-patch get_sources to return our controlled sources
+        mock_src_obj = MagicMock()
+        mock_src_obj.get_data.return_value = sources
+        ica.get_sources = MagicMock(return_value=mock_src_obj)
+
+        analysis = AutoICAAnalysis(ica_cfg)
+        diag = analysis._ica_component_diagnostics(ica, raw)
+
+        deriv_kurt = diag["spectral_deriv_kurtosis"]
+        resid_kurt = diag["spectral_resid_kurtosis"]
+
+        # Narrow-band component (index 1) should have higher kurtosis on both metrics
+        assert deriv_kurt[1] > deriv_kurt[0], (
+            f"Expected narrow-band deriv kurtosis ({deriv_kurt[1]:.2f}) > "
+            f"broadband ({deriv_kurt[0]:.2f})"
+        )
+        assert resid_kurt[1] > resid_kurt[0], (
+            f"Expected narrow-band resid kurtosis ({resid_kurt[1]:.2f}) > "
+            f"broadband ({resid_kurt[0]:.2f})"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _prepare_metrics_for_gesd
@@ -161,6 +224,8 @@ class TestPrepareMetricsForGESD:
             "autocorr_1lag": np.clip(rng.randn(n) * 0.3 + 0.5, -0.99, 0.99),
             "spectral_slope": rng.randn(n) * 0.5 - 1.5,
             "spatial_kurtosis": rng.randn(n) * 2,
+            "spectral_deriv_kurtosis": rng.randn(n) * 2,
+            "spectral_resid_kurtosis": rng.randn(n) * 2,
         }
 
     def test_returns_list_of_tuples(self, ica_cfg, sample_diagnostics):
@@ -174,10 +239,10 @@ class TestPrepareMetricsForGESD:
             assert isinstance(vals, np.ndarray)
             assert side in (-1, 0, 1)
 
-    def test_five_metrics_produced(self, ica_cfg, sample_diagnostics):
+    def test_seven_metrics_produced(self, ica_cfg, sample_diagnostics):
         analysis = AutoICAAnalysis(ica_cfg)
         metrics = analysis._prepare_metrics_for_gesd(sample_diagnostics)
-        assert len(metrics) == 5
+        assert len(metrics) == 7
 
     def test_metric_names(self, ica_cfg, sample_diagnostics):
         analysis = AutoICAAnalysis(ica_cfg)
@@ -188,6 +253,8 @@ class TestPrepareMetricsForGESD:
         assert "autocorr_fisher_z" in names
         assert "spectral_slope" in names
         assert "spatial_kurtosis_sqrt" in names
+        assert "spectral_deriv_kurtosis_sqrt" in names
+        assert "spectral_resid_kurtosis_sqrt" in names
 
     def test_directions(self, ica_cfg, sample_diagnostics):
         analysis = AutoICAAnalysis(ica_cfg)
@@ -199,6 +266,8 @@ class TestPrepareMetricsForGESD:
         assert direction_map["autocorr_fisher_z"] == -1  # low = bad
         assert direction_map["spectral_slope"] == 1
         assert direction_map["spatial_kurtosis_sqrt"] == 1
+        assert direction_map["spectral_deriv_kurtosis_sqrt"] == 1  # high = bad (sharp transitions)
+        assert direction_map["spectral_resid_kurtosis_sqrt"] == 1  # high = bad (clustered deviation)
 
     def test_no_nans_in_output(self, ica_cfg, sample_diagnostics):
         analysis = AutoICAAnalysis(ica_cfg)
@@ -217,6 +286,8 @@ class TestPrepareMetricsForGESD:
             "autocorr_1lag": np.array([0.999, -0.999, 1.0, -1.0, 0.5]),
             "spectral_slope": np.zeros(5),
             "spatial_kurtosis": np.zeros(5),
+            "spectral_deriv_kurtosis": np.zeros(5),
+            "spectral_resid_kurtosis": np.zeros(5),
         }
         metrics = analysis._prepare_metrics_for_gesd(diagnostics)
         fisher_z_vals = next(v for n, v, _ in metrics if n == "autocorr_fisher_z")


### PR DESCRIPTION
## Summary
This PR adds two new artifact detection capabilities to the AutoICA analysis:
1. **Spectral kurtosis metrics** for identifying narrow-band artifacts in ICA components
2. **Spatial template matching via corrmap** for detecting EOG/ECG artifacts without physiological reference channels

## Key Changes

### Spectral Kurtosis Metrics
- Added `spectral_deriv_kurtosis`: measures kurtosis of the spectral derivative (d(log_psd)/df), which is elevated for sharp narrow-band transitions typical of boxcar-like artifacts
- Added `spectral_resid_kurtosis`: measures kurtosis of residuals from a power-law (1/f) baseline fit, which is elevated when components deviate from natural brain spectra
- Both metrics are computed in `_ica_component_diagnostics()` and integrated into the GESD outlier detection pipeline via `_prepare_metrics_for_gesd()`
- Includes comprehensive test coverage demonstrating that narrow-band artifacts produce higher kurtosis values than broadband components

### Spatial Template Matching via Corrmap
- Implemented `_label_by_corrmap()` method that loads pre-computed topographic templates from `.npy` files and uses MNE's `corrmap` function to identify matching ICA components
- Supports both EOG and ECG artifact templates with configurable template counts
- Handles channel alignment gracefully: templates defined on a reference channel set are automatically mapped to the current ICA's (potentially smaller) channel subset
- Integrated into the main `_auto_ica()` workflow via the `_corrmap_bads` configuration flag
- Includes extensive test coverage for graceful skipping, detection accuracy, channel alignment, and integration

### Configuration Attributes
New configuration options added:
- `_corrmap_bads`: Master enable switch (default False)
- `_corrmap_template_dir`: Path to template directory
- `_n_eog_templates`: Number of EOG templates to use (default 3)
- `_n_ecg_templates`: Number of ECG templates to use (default 3)
- `_corrmap_threshold`: Correlation threshold for corrmap (default 'auto')

## Implementation Details
- Spectral metrics use signed square-root transformation to handle both positive and negative kurtosis values while preserving outlier detection directionality
- Template matching accumulates results across multiple templates of the same type to avoid overwriting previous matches
- Channel alignment uses a per-channel lookup map to handle sensor dropout and channel reordering
- Comprehensive logging at each step for debugging and transparency
- All new functionality includes graceful error handling and skip conditions

https://claude.ai/code/session_01MYY6LzmHA4qy45TCHoWs8E