### PR TITLE
fix: call mkheadsurf directly via tcsh to avoid getpwdcmd error on macOS

### DIFF
--- a/src/run/run_freesurfer.sh
+++ b/src/run/run_freesurfer.sh
@@ -77,8 +77,14 @@ echo "\n\nBuilding watershed bem..."
 mne watershed_bem --subject=$SUBJECT --subjects-dir="$SUBJECTS_DIR" --overwrite --atlas --gcaatlas --verbose
 
 # # construct hi-res head surfaces
+#echo "\n\nMaking hi-res scalp surface..."
+#mne make_scalp_surfaces --subject=$SUBJECT --subjects-dir="$SUBJECTS_DIR" --overwrite --force --verbose
+
+# construct hi-res head surfaces
+# calls mkheadsurf directly via tcsh to avoid getpwdcmd error in MNE's subprocess wrapper
 echo "\n\nMaking hi-res scalp surface..."
-mne make_scalp_surfaces --subject=$SUBJECT --subjects-dir="$SUBJECTS_DIR" --overwrite --force --verbose
+/bin/tcsh -c "setenv SUBJECTS_DIR '$SUBJECTS_DIR'; setenv FREESURFER_HOME '$FREESURFER_HOME'; source '$FREESURFER_HOME/SetUpFreeSurfer.sh'; mkheadsurf -subjid $SUBJECT -srcvol T1.mgz -thresh1 20 -thresh2 20" \
+    || echo "WARNING: make_scalp_surfaces failed (non-fatal). Hi-res scalp surface unavailable."
 
 
 # revert to original subject formatting


### PR DESCRIPTION
mne make_scalp_surfaces fails on my macOS with getpwdcmd: Command not found because MNE calls mkheadsurf via a bare subprocess, which starts tcsh without its normal initialization, leaving $getpwdcmd unset. Fixed by calling mkheadsurf directly through /bin/tcsh with SUBJECTS_DIR, FREESURFER_HOME, and SetUpFreeSurfer.sh sourced explicitly. Step is also made non-fatal since hi-res scalp surface is not required for BEM or forward modeling ( I think!)