### PR TITLE
Input file was hardcoded to processings=clean

### DIFF
--- a/src/custom/preprocessing/auto_ica.py
+++ b/src/custom/preprocessing/auto_ica.py
@@ -96,6 +96,7 @@ class AutoICAAnalysis(BaseAnalysis):
     ANALYSIS_KEY = "autoica"
     ANALYSIS_NAME = "auto_ica"
 
+    
     def is_enabled(self) -> bool:
         """Check if automatic ICA is enabled.
 
@@ -109,6 +110,7 @@ class AutoICAAnalysis(BaseAnalysis):
         auto_enabled = getattr(self.cfg, "_auto_ica", False)
         ica_enabled = getattr(self.cfg, "spatial_filter", None) == "ica"
         return auto_enabled and ica_enabled
+
 
     def load_data(self) -> Dict[str, Any]:
         """Load raw data and ICA solution.
@@ -132,7 +134,7 @@ class AutoICAAnalysis(BaseAnalysis):
             subjects=subject,
             sessions=session,
             tasks=self.cfg.task,
-            processings="clean",
+            processings=getattr(self.cfg, "_ica_input_processing", "filt"),  #can be overridden in config now if "clean" is desired.
             suffixes="raw",
             extensions=".fif",
             datatypes="meg",

--- a/src/custom/preprocessing/manual_ica.py
+++ b/src/custom/preprocessing/manual_ica.py
@@ -89,6 +89,7 @@ class ManualICAAnalysis(BaseAnalysis):
     ANALYSIS_KEY = "manualica"
     ANALYSIS_NAME = "manual_ica"
 
+
     def is_enabled(self) -> bool:
         """Check if manual ICA review is enabled.
 
@@ -125,7 +126,7 @@ class ManualICAAnalysis(BaseAnalysis):
             subjects=subject,
             sessions=session,
             tasks=self.cfg.task,
-            processings="clean",
+            processings=getattr(self.cfg, "_ica_input_processing", "filt"),  #can be overridden in config now if "clean" is desired.
             suffixes="raw",
             extensions=".fif",
             datatypes="meg",


### PR DESCRIPTION
In auto_ica.py and manual_ica.py, the input file was hardcoded to processings="clean".

My task only has proc-filt_raw.fif at that stage of the pipeline (since apply_ica hasn't run yet), so the hardcoded value would never be correct. The fix I used was to replace processings="clean" with processings=getattr(self.cfg, "_ica_input_processing", "filt"), defaulting to "filt" while allowing per-config override if needed.