### PR TITLE
Claude/custom steps deriv folder w32k n

### DIFF
--- a/docs/config-sample.py
+++ b/docs/config-sample.py
@@ -60,6 +60,15 @@ n_jobs = int(os.environ.get('MAX_WORKERS', 1))
 interactive = False         # set True (+ %matplotlib qt) for interactive plots
 process_empty_room = True   # preprocess empty-room run alongside task data
 
+# Optional: route custom preprocessing outputs through deriv_root using a
+# proc-<label> suffix instead of overwriting the raw BIDS files.
+# When set (e.g. 'init'), every custom step (bad_channels, bad_segments,
+# regress, apply_hfc, manual_channel, zca_filter) reads from / writes to
+# ``deriv_root`` with ``proc-<custom_proc>`` and the matching mne-bids-pipeline
+# run will pick up those proc-tagged files. Leave as None to overwrite the
+# raw BIDS data files (legacy behaviour).
+custom_proc = None
+
 
 # %% ============================================================
 # SECTION 3: EXPERIMENT DESIGN — run_preproc.sh / run_sensor.sh

--- a/src/custom/preprocessing/__init__.py
+++ b/src/custom/preprocessing/__init__.py
@@ -54,7 +54,14 @@ from . import (
 # Import shared utilities
 from ._base import BaseAnalysis, SEGMENT_LEN_SEC
 from ._config import load_config, normalize_analysis_key
-from ._io import save_ica_bids, get_bids_path_for_task
+from ._io import (
+    save_ica_bids,
+    get_bids_path_for_task,
+    get_custom_proc,
+    find_custom_input_paths,
+    get_custom_output_path,
+    write_raw_bids_custom_step,
+)
 from ._bids_utils import get_bids_path
 
 __all__ = [
@@ -77,4 +84,8 @@ __all__ = [
     "save_ica_bids",
     "get_bids_path_for_task",
     "get_bids_path",
+    "get_custom_proc",
+    "find_custom_input_paths",
+    "get_custom_output_path",
+    "write_raw_bids_custom_step",
 ]

--- a/src/custom/preprocessing/_io.py
+++ b/src/custom/preprocessing/_io.py
@@ -17,6 +17,21 @@ save_ica_bids
 get_bids_path_for_task
     Convenience function for creating BIDSPath from config.
 
+custom_proc helpers
+-------------------
+``cfg.custom_proc`` lets custom preprocessing steps write their results to
+``deriv_root`` under a ``proc-<custom_proc>`` BIDS suffix (e.g. ``proc-init``)
+rather than overwriting the raw files in ``bids_root``.  When set, the matching
+mne-bids-pipeline run will read its inputs from the same proc-tagged
+derivatives.  When ``custom_proc`` is unset or ``None``, the legacy behaviour
+is preserved: custom steps read from and overwrite the BIDS data files.
+
+The following helpers implement that routing:
+    get_custom_proc(cfg)
+    find_custom_input_paths(cfg, task, ...)
+    get_custom_output_path(cfg, source_bp)
+    write_raw_bids_custom_step(raw, cfg, source_bp, ...)
+
 For other operations, use mne_bids directly:
     - mne_bids.read_raw_bids() - Load raw data
     - mne_bids.write_raw_bids() - Save raw data
@@ -230,6 +245,229 @@ def get_bids_path_for_task(
     )
 
 
+# -----------------------------------------------------------------------------
+# custom_proc routing helpers
+# -----------------------------------------------------------------------------
+
+
+def get_custom_proc(cfg: SimpleNamespace) -> Optional[str]:
+    """Return ``cfg.custom_proc`` (or ``None`` if not set / empty).
+
+    Parameters
+    ----------
+    cfg : SimpleNamespace
+        Configuration object.
+
+    Returns
+    -------
+    proc : str or None
+        The value of ``cfg.custom_proc`` when truthy, otherwise ``None``.
+
+    Notes
+    -----
+    When this returns a string (e.g. ``"init"``), custom preprocessing
+    steps should read from / write to ``deriv_root`` using
+    ``processing="init"``.  When it returns ``None``, custom steps fall
+    back to the legacy behaviour of reading from / overwriting
+    ``bids_root``.
+    """
+    val = getattr(cfg, "custom_proc", None)
+    return val if val else None
+
+
+def find_custom_input_paths(
+    cfg: SimpleNamespace,
+    task: str,
+    **find_kwargs,
+) -> list[BIDSPath]:
+    """Locate input raw files for a custom preprocessing step.
+
+    When ``cfg.custom_proc`` is set, prefer files in ``deriv_root`` with
+    that processing label (e.g. ``proc-init``).  These will only exist
+    after a previous custom step has written there.  If no such files
+    exist yet (first custom step), or ``custom_proc`` is unset, fall
+    back to the raw files in ``bids_root``.
+
+    Parameters
+    ----------
+    cfg : SimpleNamespace
+        Configuration object containing BIDS settings.
+    task : str
+        Task name (e.g. ``"restingstate"``, ``"noise"``).
+    **find_kwargs
+        Extra keyword arguments forwarded to
+        :func:`mne_bids.find_matching_paths` (e.g.
+        ``runs="01"``).  ``subjects``, ``sessions``, ``tasks``,
+        ``datatypes``, ``extensions`` and ``ignore_nosub`` have sensible
+        defaults but may be overridden.
+
+    Returns
+    -------
+    paths : list of BIDSPath
+        Matching paths.  Empty list if nothing was found.
+    """
+    common = dict(
+        subjects=cfg.subjects,
+        sessions=cfg.sessions,
+        tasks=task,
+        datatypes="meg",
+        extensions=".fif",
+        ignore_nosub=True,
+    )
+    common.update(find_kwargs)
+
+    proc = get_custom_proc(cfg)
+    if proc is not None:
+        deriv_root = getattr(cfg, "deriv_root", None)
+        if deriv_root is not None and Path(deriv_root).exists():
+            deriv_paths = mne_bids.find_matching_paths(
+                root=deriv_root,
+                processings=proc,
+                check=False,
+                **common,
+            )
+            if deriv_paths:
+                return deriv_paths
+
+    return mne_bids.find_matching_paths(
+        root=cfg.bids_root,
+        **common,
+    )
+
+
+def get_custom_output_path(
+    cfg: SimpleNamespace,
+    source_bp: BIDSPath,
+) -> BIDSPath:
+    """Compute the output BIDSPath for a custom preprocessing step.
+
+    When ``cfg.custom_proc`` is set, redirects to ``deriv_root`` with
+    ``processing=cfg.custom_proc``.  Otherwise returns a copy of
+    ``source_bp`` unchanged so the legacy "write back to source"
+    behaviour is preserved.
+
+    Parameters
+    ----------
+    cfg : SimpleNamespace
+        Configuration object.
+    source_bp : BIDSPath
+        Path the data was read from.
+
+    Returns
+    -------
+    output_bp : BIDSPath
+        Path the data should be written to.
+
+    Notes
+    -----
+    The returned path always has ``check=False`` because the
+    ``proc-<custom_proc>`` label is non-canonical for raw data.
+    """
+    if source_bp is None:
+        raise ValueError("source_bp must not be None")
+
+    proc = get_custom_proc(cfg)
+    if proc is None:
+        return source_bp.copy()
+
+    return source_bp.copy().update(
+        root=cfg.deriv_root,
+        processing=proc,
+        check=False,
+    )
+
+
+def _seed_events_files(source_bp: BIDSPath, output_bp: BIDSPath) -> None:
+    """Copy events.tsv / events.json from source to destination if needed.
+
+    ``write_raw_bids_preserve_events`` backs up and restores the events
+    sidecars at the destination so that the lossy
+    annotation ↔ events.tsv round-trip does not corrupt them.  When the
+    destination is a fresh ``proc-<custom_proc>`` directory there is
+    nothing to back up yet, which means the first write would clobber
+    whatever round-trip ``write_raw_bids`` produces from
+    ``raw.annotations``.  Seeding the destination with the source's
+    events files restores the preserve-and-restore guarantee.
+    """
+    if output_bp.fpath == source_bp.fpath:
+        return
+
+    for ext in (".tsv", ".json"):
+        src = source_bp.copy().update(
+            suffix="events", extension=ext, check=False
+        ).fpath
+        dst = output_bp.copy().update(
+            suffix="events", extension=ext, check=False
+        ).fpath
+        if src.exists() and not dst.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+
+
+def write_raw_bids_custom_step(
+    raw,
+    cfg: SimpleNamespace,
+    source_bp: BIDSPath,
+    *,
+    empty_room: Optional[BIDSPath] = None,
+    **extra_write_kwargs,
+) -> BIDSPath:
+    """Write raw data, redirecting to deriv_root when ``custom_proc`` is set.
+
+    Encapsulates the common save pattern used by every custom
+    preprocessing step:
+
+    1. Resolve the output path using :func:`get_custom_output_path`.
+    2. Seed the destination's events files from the source on the first
+       redirected write so :func:`write_raw_bids_preserve_events` has
+       canonical events to preserve.
+    3. Clear ``output_bp.split`` so the write goes to the base file.
+    4. Forward the ``empty_room`` association (if provided) and any
+       extra keyword arguments to
+       :func:`write_raw_bids_preserve_events`.
+
+    Parameters
+    ----------
+    raw : mne.io.BaseRaw
+        Raw data to write.
+    cfg : SimpleNamespace
+        Configuration object.
+    source_bp : BIDSPath
+        Path the data was read from (used as the base for output path
+        construction and event-file seeding).
+    empty_room : BIDSPath or None
+        Optional empty-room association.  Should refer to the noise
+        recording at the *output* location so the BIDS association is
+        consistent with where the data is being written.
+    **extra_write_kwargs
+        Additional keyword arguments forwarded to
+        :func:`write_raw_bids_preserve_events` (e.g. ``format="FIF"``).
+        ``raw``, ``bids_path``, ``allow_preload`` and ``overwrite`` have
+        defaults but may be overridden.
+
+    Returns
+    -------
+    output_bp : BIDSPath
+        The BIDSPath the data was written to.
+    """
+    output_bp = get_custom_output_path(cfg, source_bp)
+    _seed_events_files(source_bp, output_bp)
+    output_bp.split = None
+
+    write_kwargs = dict(
+        raw=raw,
+        bids_path=output_bp,
+        allow_preload=True,
+        overwrite=True,
+        format="FIF",
+    )
+    if empty_room is not None:
+        write_kwargs["empty_room"] = empty_room
+    write_kwargs.update(extra_write_kwargs)
+    write_raw_bids_preserve_events(**write_kwargs)
+    return output_bp
+
+
 def save_ica_bids(
     ica: mne.preprocessing.ICA,
     cfg: SimpleNamespace,
@@ -317,6 +555,7 @@ def mark_bad_channels_bids(
     task: str,
     bad_channels: list[str],
     description: str = "osl",
+    bids_path: Optional[BIDSPath] = None,
 ) -> None:
     """Mark bad channels in BIDS sidecar files.
 
@@ -333,6 +572,11 @@ def mark_bad_channels_bids(
         List of channel names to mark as bad.
     description : str, optional
         Description for why channels are bad. Default is 'osl'.
+    bids_path : BIDSPath, optional
+        Explicit BIDSPath to mark.  When omitted, the path is derived
+        from ``cfg``: if ``cfg.custom_proc`` is set, the
+        ``deriv_root`` / ``proc-<custom_proc>`` location is used;
+        otherwise ``bids_root`` is used.
 
     Notes
     -----
@@ -347,7 +591,20 @@ def mark_bad_channels_bids(
     if not bad_channels:
         return
 
-    bids_path = get_bids_path_for_task(cfg, task=task, from_derivatives=False)
+    if bids_path is None:
+        proc = get_custom_proc(cfg)
+        if proc is None:
+            bids_path = get_bids_path_for_task(
+                cfg, task=task, from_derivatives=False
+            )
+        else:
+            bids_path = get_bids_path_for_task(
+                cfg, task=task, from_derivatives=False
+            ).copy().update(
+                root=cfg.deriv_root,
+                processing=proc,
+                check=False,
+            )
 
     mne_bids.mark_channels(
         bids_path=bids_path,

--- a/src/custom/preprocessing/apply_hfc.py
+++ b/src/custom/preprocessing/apply_hfc.py
@@ -61,7 +61,11 @@ import mne
 import mne_bids
 
 from ._base import BaseAnalysis
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 class ApplyHFCAnalysis(BaseAnalysis):
@@ -108,15 +112,7 @@ class ApplyHFCAnalysis(BaseAnalysis):
         data: Dict[str, Any] = {}
 
         # Load main task (search for files with runs/splits)
-        paths = mne_bids.find_matching_paths(
-            root=self.cfg.bids_root,
-            subjects=self.cfg.subjects,
-            tasks=self.cfg.task,
-            sessions=self.cfg.sessions,
-            datatypes="meg",
-            extensions=".fif",
-            ignore_nosub=True,
-        )
+        paths = find_custom_input_paths(self.cfg, task=self.cfg.task)
         if not paths:
             raise FileNotFoundError(f"No raw data found for task={self.cfg.task}")
         data[self.cfg.task] = read_raw_bids_with_retry(paths[0], extra_params={"preload": True})
@@ -124,15 +120,7 @@ class ApplyHFCAnalysis(BaseAnalysis):
 
         # Optionally load noise
         if getattr(self.cfg, "process_empty_room", False):
-            paths_noise = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+            paths_noise = find_custom_input_paths(self.cfg, task="noise")
             if paths_noise:
                 data["noise"] = read_raw_bids_with_retry(paths_noise[0], extra_params={"preload": True})
                 self.log("Loaded raw data for task=noise")
@@ -183,48 +171,25 @@ class ApplyHFCAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"bads"}}
 
-        # Find empty room path if needed
-        er_bids_path = None
-        if "noise" in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
-            if paths:
-                er_bids_path = paths[0]
+        # Process noise FIRST (when present) so the task save can use the
+        # already-written noise as its empty-room association.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            # Find existing file
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No file found for task={task}")
-            
-            bp = paths[0]
-            bp.split = None  # Clear split to write to base file
-            
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
+
+            source_bp = paths[0]
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
             )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     def _apply_hfc(

--- a/src/custom/preprocessing/bad_channels.py
+++ b/src/custom/preprocessing/bad_channels.py
@@ -56,7 +56,11 @@ from osl_ephys.preprocessing.osl_wrappers import bad_channels as osl_bad_channel
 import mne_bids
 
 from ._base import BaseAnalysis
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 class BadChannelsAnalysis(BaseAnalysis):
@@ -113,19 +117,12 @@ class BadChannelsAnalysis(BaseAnalysis):
             tasks.insert(0, "noise")
 
         for task in tasks:
-            # Search for raw files (handles runs, splits, etc.)
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+            # Search for raw files (handles runs, splits, etc.); honours
+            # cfg.custom_proc so subsequent custom steps read from deriv.
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No raw data found for task={task}")
-            
+
             raw = read_raw_bids_with_retry(paths[0], extra_params={"preload": True})
             data[task] = raw
             self.log(f"Loaded raw data for task={task}")
@@ -182,64 +179,44 @@ class BadChannelsAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"bads"}}
 
-        # Find empty room path if needed
-        er_bids_path = None
-        if "noise" in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
-            if paths:
-                er_bids_path = paths[0]
+        # Process noise FIRST (when present) so the task save can use the
+        # already-written noise as its empty-room association.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            # Find existing file to get correct run/split info
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No file found for task={task}")
-            
-            bp = paths[0]
-            
-            # Merge existing and newly detected bad channels
+
+            source_bp = paths[0]
+
+            # Merge existing and newly detected bad channels into raw.info,
+            # which write_raw_bids will reflect in the output channels.tsv.
             if unique_bads:
                 existing_bads = raw.info.get("bads", [])
                 merged_bads = sorted(set(existing_bads) | set(unique_bads))
                 raw.info["bads"] = merged_bads
                 self.log(f"task={task}: {len(merged_bads)} total bad channels")
 
-                # Update BIDS sidecar
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
+            )
+
+            # Tag the new bad channels with description="osl" in the
+            # channels.tsv that write_raw_bids just produced.
+            if unique_bads:
                 mne_bids.mark_channels(
-                    bids_path=bp,
+                    bids_path=output_bp,
                     ch_names=unique_bads,
                     status="bad",
                     descriptions="osl",
                 )
 
-            # Save raw data
-            bp.split = None  # Clear split to write to base file
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
-            )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     def _detect_bad_channels(self, raw: mne.io.BaseRaw) -> list[str]:

--- a/src/custom/preprocessing/bad_segments.py
+++ b/src/custom/preprocessing/bad_segments.py
@@ -91,7 +91,11 @@ from osl_ephys.preprocessing.osl_wrappers import bad_segments as osl_bad_segment
 import mne_bids
 
 from ._base import BaseAnalysis, SEGMENT_LEN_SEC
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 # -- Default per-stage parameters (used when config has no _bad_segments_params)
@@ -207,15 +211,7 @@ class BadSegmentsAnalysis(BaseAnalysis):
             tasks.insert(0, "noise")
 
         for task in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No raw data found for task={task}")
 
@@ -269,47 +265,27 @@ class BadSegmentsAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"bads"}}
 
-        # Find empty room path if needed
-        er_bids_path = None
-        if "noise" in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
-            if paths:
-                er_bids_path = paths[0]
+        # Process noise FIRST (when present) so its saved location can be
+        # used as the empty-room association when saving the task.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
-                raise FileNotFoundError(f"No file found for task={task} to save to")
+                raise FileNotFoundError(
+                    f"No file found for task={task} to save to"
+                )
 
-            bp = paths[0]
-            bp.split = None  # Clear split to write to base file
-
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
+            source_bp = paths[0]
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
             )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     # ------------------------------------------------------------------

--- a/src/custom/preprocessing/manual_channel.py
+++ b/src/custom/preprocessing/manual_channel.py
@@ -61,7 +61,11 @@ import mne
 import mne_bids
 
 from ._base import BaseAnalysis, have_qt_browser
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 class ManualChannelAnalysis(BaseAnalysis):
@@ -109,15 +113,7 @@ class ManualChannelAnalysis(BaseAnalysis):
         data: Dict[str, Any] = {}
 
         # Load main task (search for files with runs/splits)
-        paths = mne_bids.find_matching_paths(
-            root=self.cfg.bids_root,
-            subjects=self.cfg.subjects,
-            tasks=self.cfg.task,
-            sessions=self.cfg.sessions,
-            datatypes="meg",
-            extensions=".fif",
-            ignore_nosub=True,
-        )
+        paths = find_custom_input_paths(self.cfg, task=self.cfg.task)
         if not paths:
             raise FileNotFoundError(f"No raw data found for task={self.cfg.task}")
         data[self.cfg.task] = read_raw_bids_with_retry(paths[0], extra_params={"preload": True})
@@ -125,15 +121,7 @@ class ManualChannelAnalysis(BaseAnalysis):
 
         # Optionally load noise
         if getattr(self.cfg, "process_empty_room", False):
-            paths_noise = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+            paths_noise = find_custom_input_paths(self.cfg, task="noise")
             if paths_noise:
                 data["noise"] = read_raw_bids_with_retry(paths_noise[0], extra_params={"preload": True})
                 self.log("Loaded raw data for task=noise")
@@ -187,59 +175,39 @@ class ManualChannelAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"bads"}}
 
-        # Find empty room path if needed
-        er_bids_path = None
-        if "noise" in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
-            if paths:
-                er_bids_path = paths[0]
+        # Process noise FIRST (when present) so the task save can use the
+        # already-written noise as its empty-room association.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            # Find existing file
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No file found for task={task}")
-            
-            bp = paths[0]
-            
-            # Update raw info with bad channels
+
+            source_bp = paths[0]
+
             if unique_bads:
                 raw.info["bads"] = unique_bads
+
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
+            )
+
+            # Tag the user-selected bad channels with description="osl"
+            # in the channels.tsv that write_raw_bids just produced.
+            if unique_bads:
                 mne_bids.mark_channels(
-                    bids_path=bp,
+                    bids_path=output_bp,
                     ch_names=unique_bads,
                     status="bad",
                     descriptions="osl",
                 )
 
-            # Save raw data
-            bp.split = None  # Clear split to write to base file
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
-            )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     def _manual_channel_selection(

--- a/src/custom/preprocessing/regress.py
+++ b/src/custom/preprocessing/regress.py
@@ -77,7 +77,11 @@ from scipy import stats
 from scipy.linalg import qr
 
 from ._base import BaseAnalysis
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 class RegressAnalysis(BaseAnalysis):
@@ -139,16 +143,7 @@ class RegressAnalysis(BaseAnalysis):
             tasks.insert(0, "noise")
 
         for task in tasks:
-            # Search for raw files (handles runs, splits, etc.)
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No raw data found for task={task}")
 
@@ -195,49 +190,25 @@ class RegressAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"bads"}}
 
-        # Find empty room path if needed
-        er_bids_path = None
-        if "noise" in tasks:
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks="noise",
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
-            if paths:
-                er_bids_path = paths[0]
+        # Process noise FIRST (when present) so the task save can use the
+        # already-written noise as its empty-room association.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            # Find existing file
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No file found for task={task}")
 
-            bp = paths[0]
-            bp.split = None  # Clear split to write to base file
-
-            # Associate with empty room for non-noise tasks
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
+            source_bp = paths[0]
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
             )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     def _regress(

--- a/src/custom/preprocessing/zca_filter.py
+++ b/src/custom/preprocessing/zca_filter.py
@@ -105,7 +105,11 @@ from mne.preprocessing.maxwell import _prep_mf_coils, _sss_basis
 from scipy.linalg import eigh, null_space
 
 from ._base import BaseAnalysis
-from ._io import write_raw_bids_preserve_events, read_raw_bids_with_retry
+from ._io import (
+    find_custom_input_paths,
+    read_raw_bids_with_retry,
+    write_raw_bids_custom_step,
+)
 
 
 class ZCAFilterAnalysis(BaseAnalysis):
@@ -162,32 +166,16 @@ class ZCAFilterAnalysis(BaseAnalysis):
         self.log(f"FreeSurfer subject: {fs_subject}")
 
         # Load main task data
-        paths = mne_bids.find_matching_paths(
-            root=self.cfg.bids_root,
-            subjects=self.cfg.subjects,
-            tasks=self.cfg.task,
-            sessions=self.cfg.sessions,
-            datatypes="meg",
-            extensions=".fif",
-            ignore_nosub=True,
-        )
+        paths = find_custom_input_paths(self.cfg, task=self.cfg.task)
         if not paths:
             raise FileNotFoundError(f"No raw data found for task={self.cfg.task}")
-        
+
         data["bids_path"] = paths[0]
         data["raw"] = read_raw_bids_with_retry(paths[0], extra_params={"preload": True})
         self.log(f"Loaded raw data for task={self.cfg.task}")
 
         # Load noise data (required for ZCA)
-        paths_noise = mne_bids.find_matching_paths(
-            root=self.cfg.bids_root,
-            subjects=self.cfg.subjects,
-            tasks="noise",
-            sessions=self.cfg.sessions,
-            datatypes="meg",
-            extensions=".fif",
-            ignore_nosub=True,
-        )
+        paths_noise = find_custom_input_paths(self.cfg, task="noise")
         if not paths_noise:
             raise FileNotFoundError(
                 "No noise recording found. ZCA requires task='noise' data "
@@ -264,47 +252,25 @@ class ZCAFilterAnalysis(BaseAnalysis):
         # Separate task data from metadata
         tasks = {k: v for k, v in results.items() if k not in {"projs"}}
 
-        # Find empty room path for association
-        er_bids_path = None
-        paths = mne_bids.find_matching_paths(
-            root=self.cfg.bids_root,
-            subjects=self.cfg.subjects,
-            tasks="noise",
-            sessions=self.cfg.sessions,
-            datatypes="meg",
-            extensions=".fif",
-            ignore_nosub=True,
-        )
-        if paths:
-            er_bids_path = paths[0]
+        # Process noise FIRST (when present) so the task save can use the
+        # already-written noise as its empty-room association.
+        ordered_tasks = sorted(tasks.items(), key=lambda kv: kv[0] != "noise")
 
-        for task, raw in tasks.items():
-            # Find existing file
-            paths = mne_bids.find_matching_paths(
-                root=self.cfg.bids_root,
-                subjects=self.cfg.subjects,
-                tasks=task,
-                sessions=self.cfg.sessions,
-                datatypes="meg",
-                extensions=".fif",
-                ignore_nosub=True,
-            )
+        er_output_bp = None
+        for task, raw in ordered_tasks:
+            paths = find_custom_input_paths(self.cfg, task=task)
             if not paths:
                 raise FileNotFoundError(f"No file found for task={task}")
 
-            bp = paths[0]
-            bp.split = None  # Clear split to write to base file
-
-            write_kwargs = dict(
-                raw=raw,
-                bids_path=bp,
-                allow_preload=True,
-                overwrite=True,
-                format="FIF",
+            source_bp = paths[0]
+            empty_room = er_output_bp if task != "noise" else None
+            output_bp = write_raw_bids_custom_step(
+                raw, self.cfg, source_bp, empty_room=empty_room
             )
-            if er_bids_path and task != "noise":
-                write_kwargs["empty_room"] = er_bids_path
-            write_raw_bids_preserve_events(**write_kwargs)
+
+            if task == "noise":
+                er_output_bp = output_bp
+
             self.log(f"Saved task={task}")
 
     def _get_fs_subject(self) -> str:

--- a/src/mne_opm.egg-info/SOURCES.txt
+++ b/src/mne_opm.egg-info/SOURCES.txt
@@ -2,6 +2,7 @@ LICENSE
 README.md
 pyproject.toml
 src/custom/__init__.py
+src/custom/coreg_diagnostics.py
 src/custom/custom_preproc.py
 src/custom/format_bids.py
 src/custom/run_beamformer.py
@@ -47,6 +48,7 @@ tests/test_base.py
 tests/test_beamformer.py
 tests/test_beamformer_extended.py
 tests/test_config.py
+tests/test_coreg_diagnostics.py
 tests/test_custom_preproc.py
 tests/test_custom_preproc_extended.py
 tests/test_decoding.py

--- a/tests/test_apply_hfc.py
+++ b/tests/test_apply_hfc.py
@@ -150,10 +150,10 @@ class TestHFCRun:
 
 class TestHFCLoadData:
     @patch("custom.preprocessing.apply_hfc.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_load_task_data(self, mock_bids, mock_read, raw_meg, hfc_cfg):
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_load_task_data(self, mock_find, mock_read, raw_meg, hfc_cfg):
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = ApplyHFCAnalysis(hfc_cfg)
@@ -163,11 +163,11 @@ class TestHFCLoadData:
         mock_read.assert_called_once()
 
     @patch("custom.preprocessing.apply_hfc.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_load_with_noise(self, mock_bids, mock_read, raw_meg, hfc_cfg):
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_load_with_noise(self, mock_find, mock_read, raw_meg, hfc_cfg):
         hfc_cfg.process_empty_room = True
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = ApplyHFCAnalysis(hfc_cfg)
@@ -176,9 +176,9 @@ class TestHFCLoadData:
         assert "noise" in data
         assert hfc_cfg.task in data
 
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_load_no_files_raises(self, mock_bids, hfc_cfg):
-        mock_bids.find_matching_paths.return_value = []
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_load_no_files_raises(self, mock_find, hfc_cfg):
+        mock_find.return_value = []
         analysis = ApplyHFCAnalysis(hfc_cfg)
         with pytest.raises(FileNotFoundError):
             analysis.load_data()
@@ -189,12 +189,13 @@ class TestHFCLoadData:
 # ---------------------------------------------------------------------------
 
 class TestHFCSaveResults:
-    @patch("custom.preprocessing.apply_hfc.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_save_writes_data(self, mock_bids, mock_write, raw_meg, hfc_cfg):
+    @patch("custom.preprocessing.apply_hfc.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_save_writes_data(self, mock_find, mock_write, raw_meg, hfc_cfg):
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp
 
         analysis = ApplyHFCAnalysis(hfc_cfg)
         results = {hfc_cfg.task: raw_meg, "bads": []}
@@ -202,12 +203,13 @@ class TestHFCSaveResults:
 
         mock_write.assert_called_once()
 
-    @patch("custom.preprocessing.apply_hfc.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_save_with_empty_room(self, mock_bids, mock_write, raw_meg, hfc_cfg):
+    @patch("custom.preprocessing.apply_hfc.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_save_with_empty_room(self, mock_find, mock_write, raw_meg, hfc_cfg):
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp
 
         analysis = ApplyHFCAnalysis(hfc_cfg)
         results = {"noise": raw_meg, hfc_cfg.task: raw_meg, "bads": []}
@@ -238,14 +240,15 @@ class TestHFCEnabled:
 # ---------------------------------------------------------------------------
 
 class TestHFCModuleRun:
-    @patch("custom.preprocessing.apply_hfc.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.apply_hfc.write_raw_bids_custom_step")
     @patch("custom.preprocessing.apply_hfc.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.apply_hfc.mne_bids")
-    def test_run_end_to_end(self, mock_bids, mock_read, mock_write, raw_meg, hfc_cfg):
+    @patch("custom.preprocessing.apply_hfc.find_custom_input_paths")
+    def test_run_end_to_end(self, mock_find, mock_read, mock_write, raw_meg, hfc_cfg):
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
+        mock_write.return_value = mock_bp
 
         run(hfc_cfg)
 

--- a/tests/test_bad_channels.py
+++ b/tests/test_bad_channels.py
@@ -122,14 +122,14 @@ class TestBadChannelsRun:
 # ---------------------------------------------------------------------------
 
 class TestBadChannelsLoadData:
-    """Test load_data with mocked mne_bids calls."""
+    """Test load_data with mocked path-resolution calls."""
 
     @patch("custom.preprocessing.bad_channels.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_load_single_task(self, mock_bids, mock_read, raw_meg, bad_ch_cfg):
-        """load_data should call find_matching_paths and read_raw_bids."""
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_load_single_task(self, mock_find, mock_read, raw_meg, bad_ch_cfg):
+        """load_data should resolve input paths and read raw."""
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = BadChannelsAnalysis(bad_ch_cfg)
@@ -137,16 +137,16 @@ class TestBadChannelsLoadData:
 
         assert bad_ch_cfg.task in data
         assert data[bad_ch_cfg.task] is raw_meg
-        mock_bids.find_matching_paths.assert_called_once()
+        mock_find.assert_called_once()
         mock_read.assert_called_once()
 
     @patch("custom.preprocessing.bad_channels.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_load_with_empty_room(self, mock_bids, mock_read, raw_meg, bad_ch_cfg):
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_load_with_empty_room(self, mock_find, mock_read, raw_meg, bad_ch_cfg):
         """When process_empty_room=True, load noise + task."""
         bad_ch_cfg.process_empty_room = True
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = BadChannelsAnalysis(bad_ch_cfg)
@@ -154,12 +154,12 @@ class TestBadChannelsLoadData:
 
         assert "noise" in data
         assert bad_ch_cfg.task in data
-        assert mock_bids.find_matching_paths.call_count == 2
+        assert mock_find.call_count == 2
 
-    @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_load_missing_task_raises(self, mock_bids, bad_ch_cfg):
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_load_missing_task_raises(self, mock_find, bad_ch_cfg):
         """load_data raises FileNotFoundError if no paths found."""
-        mock_bids.find_matching_paths.return_value = []
+        mock_find.return_value = []
 
         analysis = BadChannelsAnalysis(bad_ch_cfg)
         with pytest.raises(FileNotFoundError, match="No raw data"):
@@ -171,15 +171,19 @@ class TestBadChannelsLoadData:
 # ---------------------------------------------------------------------------
 
 class TestBadChannelsSaveResults:
-    """Test save_results merges bads and calls write_raw_bids."""
+    """Test save_results merges bads and calls write_raw_bids_custom_step."""
 
-    @patch("custom.preprocessing.bad_channels.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.bad_channels.write_raw_bids_custom_step")
     @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_save_merges_bads_into_raw(self, mock_bids, mock_write, raw_meg, bad_ch_cfg):
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_save_merges_bads_into_raw(
+        self, mock_find, mock_bids, mock_write, raw_meg, bad_ch_cfg
+    ):
         """save_results should merge detected bads into raw.info['bads']."""
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp  # output bp
 
         analysis = BadChannelsAnalysis(bad_ch_cfg)
         results = {bad_ch_cfg.task: raw_meg, "bads": ["MEG001", "MEG003"]}
@@ -188,18 +192,22 @@ class TestBadChannelsSaveResults:
         # Verify bads were merged into raw.info
         assert "MEG001" in raw_meg.info["bads"]
         assert "MEG003" in raw_meg.info["bads"]
-        # Verify mark_channels was called
+        # Verify mark_channels was called (after the redirected write)
         mock_bids.mark_channels.assert_called()
-        # Verify write_raw_bids_preserve_events was called
+        # Verify write_raw_bids_custom_step was called
         mock_write.assert_called()
 
-    @patch("custom.preprocessing.bad_channels.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.bad_channels.write_raw_bids_custom_step")
     @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_save_no_bads_still_writes(self, mock_bids, mock_write, raw_meg, bad_ch_cfg):
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_save_no_bads_still_writes(
+        self, mock_find, mock_bids, mock_write, raw_meg, bad_ch_cfg
+    ):
         """save_results with empty bads should still write raw."""
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp
 
         analysis = BadChannelsAnalysis(bad_ch_cfg)
         results = {bad_ch_cfg.task: raw_meg, "bads": []}
@@ -217,15 +225,18 @@ class TestBadChannelsSaveResults:
 class TestBadChannelsModuleRun:
     """Test the module-level run(cfg) function."""
 
-    @patch("custom.preprocessing.bad_channels.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.bad_channels.write_raw_bids_custom_step")
     @patch("custom.preprocessing.bad_channels.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_channels.mne_bids")
-    def test_run_calls_execute(self, mock_bids, mock_read, mock_write, raw_meg, bad_ch_cfg):
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_run_calls_execute(
+        self, mock_find, mock_read, mock_write, raw_meg, bad_ch_cfg
+    ):
         """run(cfg) should construct the analysis and call execute."""
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
+        mock_write.return_value = mock_bp
 
         # This exercises: run(cfg) -> is_enabled -> execute -> load/run/save
         run(bad_ch_cfg)

--- a/tests/test_bad_segments.py
+++ b/tests/test_bad_segments.py
@@ -142,15 +142,15 @@ class TestBadSegmentsRun:
 # ---------------------------------------------------------------------------
 
 class TestBadSegmentsLoadData:
-    """Test load_data with mocked mne_bids calls."""
+    """Test load_data with mocked path-resolution calls."""
 
     @patch("custom.preprocessing.bad_segments.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_segments.mne_bids")
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
     def test_load_single_task(
-        self, mock_bids, mock_read, raw_with_artifact_segment, bad_seg_cfg
+        self, mock_find, mock_read, raw_with_artifact_segment, bad_seg_cfg
     ):
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_with_artifact_segment
 
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
@@ -160,13 +160,13 @@ class TestBadSegmentsLoadData:
         mock_read.assert_called_once()
 
     @patch("custom.preprocessing.bad_segments.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_segments.mne_bids")
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
     def test_load_with_empty_room(
-        self, mock_bids, mock_read, raw_with_artifact_segment, bad_seg_cfg
+        self, mock_find, mock_read, raw_with_artifact_segment, bad_seg_cfg
     ):
         bad_seg_cfg.process_empty_room = True
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_with_artifact_segment
 
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
@@ -175,9 +175,9 @@ class TestBadSegmentsLoadData:
         assert "noise" in data
         assert bad_seg_cfg.task in data
 
-    @patch("custom.preprocessing.bad_segments.mne_bids")
-    def test_load_no_files_raises(self, mock_bids, bad_seg_cfg):
-        mock_bids.find_matching_paths.return_value = []
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
+    def test_load_no_files_raises(self, mock_find, bad_seg_cfg):
+        mock_find.return_value = []
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
         with pytest.raises(FileNotFoundError, match="No raw data"):
             analysis.load_data()
@@ -188,12 +188,15 @@ class TestBadSegmentsLoadData:
 # ---------------------------------------------------------------------------
 
 class TestBadSegmentsSaveResults:
-    @patch("custom.preprocessing.bad_segments.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.bad_segments.mne_bids")
-    def test_save_writes_annotated_raw(self, mock_bids, mock_write, raw_meg, bad_seg_cfg):
+    @patch("custom.preprocessing.bad_segments.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
+    def test_save_writes_annotated_raw(
+        self, mock_find, mock_write, raw_meg, bad_seg_cfg
+    ):
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp
 
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
         results = {bad_seg_cfg.task: raw_meg, "bads": []}
@@ -201,23 +204,31 @@ class TestBadSegmentsSaveResults:
 
         mock_write.assert_called_once()
 
-    @patch("custom.preprocessing.bad_segments.mne_bids")
-    def test_save_no_paths_raises(self, mock_bids, raw_meg, bad_seg_cfg):
-        mock_bids.find_matching_paths.return_value = []
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
+    def test_save_no_paths_raises(self, mock_find, raw_meg, bad_seg_cfg):
+        mock_find.return_value = []
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
         results = {bad_seg_cfg.task: raw_meg, "bads": []}
         with pytest.raises(FileNotFoundError, match="No file found"):
             analysis.save_results(results)
 
-    @patch("custom.preprocessing.bad_segments.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.bad_segments.mne_bids")
+    @patch("custom.preprocessing.bad_segments.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
     def test_save_with_empty_room_association(
-        self, mock_bids, mock_write, raw_meg, bad_seg_cfg
+        self, mock_find, mock_write, raw_meg, bad_seg_cfg
     ):
         """save_results should pass empty_room kwarg for task data."""
-        mock_bp = MagicMock()
-        mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        # Create distinct BP objects for noise and task to verify
+        # the empty-room association is wired up correctly.
+        noise_bp = MagicMock(name="noise_bp")
+        task_bp = MagicMock(name="task_bp")
+        noise_bp.split = None
+        task_bp.split = None
+
+        # noise is processed FIRST, so first find call returns noise_bp
+        mock_find.side_effect = [[noise_bp], [task_bp]]
+        # write returns the output bp (use the same input bp as a stand-in)
+        mock_write.side_effect = [noise_bp, task_bp]
 
         analysis = BadSegmentsAnalysis(bad_seg_cfg)
         results = {"noise": raw_meg, bad_seg_cfg.task: raw_meg, "bads": []}
@@ -225,9 +236,9 @@ class TestBadSegmentsSaveResults:
 
         # Should write both noise and task
         assert mock_write.call_count == 2
-        # The task write should include empty_room
+        # The task write should include empty_room=noise_bp
         task_call_kwargs = mock_write.call_args_list[-1][1]
-        assert "empty_room" in task_call_kwargs
+        assert task_call_kwargs.get("empty_room") is noise_bp
 
 
 # ---------------------------------------------------------------------------
@@ -235,17 +246,18 @@ class TestBadSegmentsSaveResults:
 # ---------------------------------------------------------------------------
 
 class TestBadSegmentsModuleRun:
-    @patch("custom.preprocessing.bad_segments.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.bad_segments.write_raw_bids_custom_step")
     @patch("custom.preprocessing.bad_segments.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.bad_segments.mne_bids")
+    @patch("custom.preprocessing.bad_segments.find_custom_input_paths")
     def test_run_entry_point(
-        self, mock_bids, mock_read, mock_write, raw_with_artifact_segment, bad_seg_cfg
+        self, mock_find, mock_read, mock_write, raw_with_artifact_segment, bad_seg_cfg
     ):
         """End-to-end: run(cfg) should load, detect, and save."""
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_with_artifact_segment
+        mock_write.return_value = mock_bp
 
         run(bad_seg_cfg)
 

--- a/tests/test_custom_proc.py
+++ b/tests/test_custom_proc.py
@@ -1,0 +1,667 @@
+"""Tests for the ``custom_proc`` deriv routing in ``preprocessing._io``.
+
+When ``cfg.custom_proc`` is set (e.g. ``'init'``), custom preprocessing
+steps must:
+
+1. Read inputs from ``deriv_root`` with ``proc-<custom_proc>`` if files
+   exist there, otherwise fall back to ``bids_root``.
+2. Write outputs to ``deriv_root`` with ``proc-<custom_proc>`` instead
+   of overwriting the BIDS data files.
+
+When ``cfg.custom_proc`` is unset / ``None``, behaviour falls back to
+the legacy contract of reading from / writing to ``bids_root``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mne
+import mne_bids
+import numpy as np
+import pytest
+from mne_bids import BIDSPath
+
+from custom.preprocessing._io import (
+    find_custom_input_paths,
+    get_custom_output_path,
+    get_custom_proc,
+    write_raw_bids_custom_step,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cfg(tmp_path, **overrides):
+    defaults = dict(
+        bids_root=str(tmp_path / "bids"),
+        deriv_root=str(tmp_path / "derivatives"),
+        subjects=["001"],
+        sessions=["01"],
+        task="restingstate",
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _make_bids_path(root, **overrides):
+    defaults = dict(
+        root=str(root),
+        subject="001",
+        session="01",
+        task="restingstate",
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+    )
+    defaults.update(overrides)
+    return BIDSPath(**defaults)
+
+
+def _write_minimal_raw_to_bids(bids_root: Path, raw, task: str = "restingstate"):
+    """Write a minimal raw file to a BIDS dataset for testing.
+
+    Returns the BIDSPath that was written.
+    """
+    bp = BIDSPath(
+        root=str(bids_root),
+        subject="001",
+        session="01",
+        task=task,
+        datatype="meg",
+        suffix="meg",
+        extension=".fif",
+    )
+    raw.set_meas_date(None)
+    mne_bids.write_raw_bids(
+        raw=raw,
+        bids_path=bp,
+        allow_preload=True,
+        overwrite=True,
+        format="FIF",
+    )
+    return bp
+
+
+# ---------------------------------------------------------------------------
+# get_custom_proc
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomProc:
+    """get_custom_proc unwraps the cfg attribute, returning None if unset."""
+
+    def test_missing_attribute_returns_none(self, tmp_path):
+        cfg = _make_cfg(tmp_path)
+        assert get_custom_proc(cfg) is None
+
+    def test_none_attribute_returns_none(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc=None)
+        assert get_custom_proc(cfg) is None
+
+    def test_empty_string_returns_none(self, tmp_path):
+        """Empty string should be treated as unset."""
+        cfg = _make_cfg(tmp_path, custom_proc="")
+        assert get_custom_proc(cfg) is None
+
+    def test_string_value_returned_verbatim(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        assert get_custom_proc(cfg) == "init"
+
+    def test_other_string_value(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc="cleaned")
+        assert get_custom_proc(cfg) == "cleaned"
+
+
+# ---------------------------------------------------------------------------
+# get_custom_output_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomOutputPath:
+    """get_custom_output_path redirects writes when custom_proc is set."""
+
+    def test_no_custom_proc_returns_source_unchanged(self, tmp_path):
+        cfg = _make_cfg(tmp_path)  # no custom_proc
+        source_bp = _make_bids_path(tmp_path / "bids")
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        assert str(output_bp.root) == str(source_bp.root)
+        assert output_bp.processing == source_bp.processing  # both None
+
+    def test_custom_proc_redirects_to_deriv_root(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        source_bp = _make_bids_path(tmp_path / "bids")
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        assert str(output_bp.root) == cfg.deriv_root
+        assert output_bp.processing == "init"
+
+    def test_custom_proc_preserves_subject_session_task(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        source_bp = _make_bids_path(
+            tmp_path / "bids", subject="002", session="03", task="other"
+        )
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        assert output_bp.subject == "002"
+        assert output_bp.session == "03"
+        assert output_bp.task == "other"
+
+    def test_custom_proc_filename_includes_proc_label(self, tmp_path):
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        source_bp = _make_bids_path(tmp_path / "bids")
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        assert "proc-init" in str(output_bp.fpath)
+
+    def test_returns_independent_copy(self, tmp_path):
+        """Mutating the returned bp should not affect the source bp."""
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        source_bp = _make_bids_path(tmp_path / "bids")
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        output_bp.update(task="otherTask", check=False)
+        assert source_bp.task == "restingstate"
+
+    def test_returns_copy_when_proc_unset(self, tmp_path):
+        """Even with no custom_proc, the returned bp should be a copy."""
+        cfg = _make_cfg(tmp_path)
+        source_bp = _make_bids_path(tmp_path / "bids")
+
+        output_bp = get_custom_output_path(cfg, source_bp)
+        output_bp.update(task="otherTask")
+        assert source_bp.task == "restingstate"
+
+
+# ---------------------------------------------------------------------------
+# find_custom_input_paths
+# ---------------------------------------------------------------------------
+
+
+class TestFindCustomInputPaths:
+    """find_custom_input_paths prefers deriv proc-* files when custom_proc is set."""
+
+    def test_falls_back_to_bids_root_when_proc_unset(
+        self, tmp_path, raw_meg
+    ):
+        """Without custom_proc, only the BIDS root is searched."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = _make_cfg(tmp_path)  # no custom_proc
+
+        paths = find_custom_input_paths(cfg, task="restingstate")
+        assert len(paths) == 1
+        assert str(paths[0].root) == str(bids_root)
+        assert paths[0].processing is None
+
+    def test_falls_back_to_bids_root_when_no_deriv_files(
+        self, tmp_path, raw_meg
+    ):
+        """With custom_proc set but no deriv files yet, returns bids_root."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+
+        paths = find_custom_input_paths(cfg, task="restingstate")
+        assert len(paths) == 1
+        assert str(paths[0].root) == str(bids_root)
+        assert paths[0].processing is None
+
+    def test_prefers_deriv_when_proc_files_exist(self, tmp_path, raw_meg):
+        """With custom_proc set and deriv files present, those are used."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        # Also write a proc-init copy under deriv_root
+        deriv_root = tmp_path / "derivatives"
+        deriv_root.mkdir()
+        deriv_bp = BIDSPath(
+            root=str(deriv_root),
+            subject="001",
+            session="01",
+            task="restingstate",
+            datatype="meg",
+            suffix="meg",
+            processing="init",
+            extension=".fif",
+            check=False,
+        )
+        mne_bids.write_raw_bids(
+            raw=raw_meg,
+            bids_path=deriv_bp,
+            allow_preload=True,
+            overwrite=True,
+            format="FIF",
+        )
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        paths = find_custom_input_paths(cfg, task="restingstate")
+        assert len(paths) == 1
+        assert str(paths[0].root) == str(deriv_root)
+        assert paths[0].processing == "init"
+
+    def test_returns_empty_when_no_files(self, tmp_path):
+        """If neither deriv nor bids has files, returns []."""
+        (tmp_path / "bids").mkdir()
+        cfg = _make_cfg(tmp_path)
+        paths = find_custom_input_paths(cfg, task="restingstate")
+        assert paths == []
+
+    def test_handles_missing_deriv_root(self, tmp_path, raw_meg):
+        """A non-existent deriv_root doesn't raise; we fall back to bids."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        # deriv_root has not been created
+        assert not Path(cfg.deriv_root).exists()
+
+        paths = find_custom_input_paths(cfg, task="restingstate")
+        assert len(paths) == 1
+        assert str(paths[0].root) == str(bids_root)
+
+
+# ---------------------------------------------------------------------------
+# write_raw_bids_custom_step
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRawBidsCustomStep:
+    """End-to-end behaviour of write_raw_bids_custom_step."""
+
+    def test_writes_to_bids_root_when_proc_unset(self, tmp_path, raw_meg):
+        """With custom_proc unset, writes back to the source BIDS file."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        source_bp = _write_minimal_raw_to_bids(
+            bids_root, raw_meg, task="restingstate"
+        )
+
+        cfg = _make_cfg(tmp_path)  # no custom_proc
+
+        # Modify raw and write back
+        raw_meg.info["bads"] = ["MEG001"]
+        output_bp = write_raw_bids_custom_step(raw_meg, cfg, source_bp)
+
+        assert str(output_bp.root) == str(bids_root)
+        assert output_bp.processing is None
+        assert output_bp.fpath.exists()
+
+    def test_writes_to_deriv_with_proc_when_set(self, tmp_path, raw_meg):
+        """With custom_proc set, writes go to deriv_root with proc-* tag."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        source_bp = _write_minimal_raw_to_bids(
+            bids_root, raw_meg, task="restingstate"
+        )
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        output_bp = write_raw_bids_custom_step(raw_meg, cfg, source_bp)
+
+        assert str(output_bp.root) == cfg.deriv_root
+        assert output_bp.processing == "init"
+        assert output_bp.fpath.exists()
+        # The proc-init filename should be used
+        assert "proc-init" in str(output_bp.fpath)
+
+    def test_does_not_modify_bids_root_when_redirected(
+        self, tmp_path, raw_meg
+    ):
+        """A redirected write must NOT touch the BIDS data file."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        source_bp = _write_minimal_raw_to_bids(
+            bids_root, raw_meg, task="restingstate"
+        )
+        original_mtime = source_bp.fpath.stat().st_mtime
+        original_size = source_bp.fpath.stat().st_size
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        # Mark a channel bad so the write would change the file content if
+        # it did go to bids_root.
+        raw_meg.info["bads"] = ["MEG001"]
+        write_raw_bids_custom_step(raw_meg, cfg, source_bp)
+
+        # bids_root file should be untouched
+        assert source_bp.fpath.stat().st_mtime == original_mtime
+        assert source_bp.fpath.stat().st_size == original_size
+
+    def test_seeds_events_files_on_first_redirected_write(
+        self, tmp_path, raw_with_stim
+    ):
+        """Events files are copied from source on first redirected write."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+
+        # Write raw + events to BIDS
+        events = mne.find_events(raw_with_stim, stim_channel="STI001")
+        bp = BIDSPath(
+            root=str(bids_root), subject="001", session="01",
+            task="restingstate", datatype="meg", suffix="meg",
+            extension=".fif",
+        )
+        mne_bids.write_raw_bids(
+            raw=raw_with_stim,
+            bids_path=bp,
+            events=events,
+            event_id={"trig1": 1, "trig2": 2},
+            allow_preload=True,
+            overwrite=True,
+            format="FIF",
+        )
+
+        source_events = bp.copy().update(suffix="events", extension=".tsv").fpath
+        assert source_events.exists()
+        source_event_lines = source_events.read_text().splitlines()
+
+        cfg = _make_cfg(tmp_path, custom_proc="init")
+        output_bp = write_raw_bids_custom_step(raw_with_stim, cfg, bp)
+
+        # The redirected write should have an events.tsv next to it that
+        # matches the source (the seed plus preserve+restore).
+        deriv_events = output_bp.copy().update(
+            suffix="events", extension=".tsv"
+        ).fpath
+        assert deriv_events.exists()
+        assert deriv_events.read_text().splitlines() == source_event_lines
+
+    def test_forwards_empty_room(self, tmp_path, raw_meg):
+        """The empty_room kwarg is forwarded to write_raw_bids."""
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        source_bp = _write_minimal_raw_to_bids(
+            bids_root, raw_meg, task="restingstate"
+        )
+        er_bp = _write_minimal_raw_to_bids(bids_root, raw_meg, task="noise")
+
+        cfg = _make_cfg(tmp_path)
+        # Should accept empty_room without raising
+        output_bp = write_raw_bids_custom_step(
+            raw_meg, cfg, source_bp, empty_room=er_bp
+        )
+        assert output_bp.fpath.exists()
+
+
+# ---------------------------------------------------------------------------
+# Module integration: bad_channels.save_results respects custom_proc
+# ---------------------------------------------------------------------------
+
+
+class TestBadChannelsRespectsCustomProc:
+    """Verify bad_channels.save_results writes to deriv when custom_proc set."""
+
+    def test_save_redirects_when_custom_proc_set(self, tmp_path, raw_meg):
+        """End-to-end: custom_proc='init' writes to deriv_root proc-init."""
+        from custom.preprocessing.bad_channels import BadChannelsAnalysis
+
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = SimpleNamespace(
+            bids_root=str(bids_root),
+            deriv_root=str(tmp_path / "derivatives"),
+            subjects=["001"],
+            sessions=["01"],
+            task="restingstate",
+            ch_types=["mag"],
+            l_freq=1.0,
+            h_freq=100.0,
+            process_empty_room=False,
+            find_breaks=False,
+            n_jobs=1,
+            custom_proc="init",
+        )
+
+        analysis = BadChannelsAnalysis(cfg)
+        results = {cfg.task: raw_meg, "bads": ["MEG001"]}
+        analysis.save_results(results)
+
+        # Output file must exist in deriv_root with proc-init label
+        deriv_file = (
+            Path(cfg.deriv_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_proc-init_meg.fif"
+        )
+        assert deriv_file.exists()
+
+        # bids_root file should not have the bad channels marked (untouched)
+        bids_channels_tsv = (
+            Path(cfg.bids_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_channels.tsv"
+        )
+        # The original write set MEG001 as good; after our redirect, the
+        # bids_root channels.tsv must still mark it as good.
+        text = bids_channels_tsv.read_text()
+        # find MEG001 row
+        for line in text.splitlines():
+            if line.startswith("MEG001\t"):
+                assert "good" in line.lower()
+                break
+
+        # The deriv channels.tsv should mark MEG001 as bad
+        deriv_channels_tsv = (
+            Path(cfg.deriv_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_proc-init_channels.tsv"
+        )
+        text = deriv_channels_tsv.read_text()
+        for line in text.splitlines():
+            if line.startswith("MEG001\t"):
+                assert "bad" in line.lower()
+                break
+
+    def test_save_overwrites_bids_when_custom_proc_unset(
+        self, tmp_path, raw_meg
+    ):
+        """Without custom_proc, save_results overwrites bids_root (legacy)."""
+        from custom.preprocessing.bad_channels import BadChannelsAnalysis
+
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = SimpleNamespace(
+            bids_root=str(bids_root),
+            deriv_root=str(tmp_path / "derivatives"),
+            subjects=["001"],
+            sessions=["01"],
+            task="restingstate",
+            ch_types=["mag"],
+            l_freq=1.0,
+            h_freq=100.0,
+            process_empty_room=False,
+            find_breaks=False,
+            n_jobs=1,
+        )
+
+        analysis = BadChannelsAnalysis(cfg)
+        results = {cfg.task: raw_meg, "bads": ["MEG001"]}
+        analysis.save_results(results)
+
+        # No deriv file should appear
+        deriv_file = (
+            Path(cfg.deriv_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_proc-init_meg.fif"
+        )
+        assert not deriv_file.exists()
+
+        # bids_root channels.tsv should now mark MEG001 as bad
+        bids_channels_tsv = (
+            Path(cfg.bids_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_channels.tsv"
+        )
+        text = bids_channels_tsv.read_text()
+        marked_bad = False
+        for line in text.splitlines():
+            if line.startswith("MEG001\t"):
+                marked_bad = "bad" in line.lower()
+                break
+        assert marked_bad
+
+
+# ---------------------------------------------------------------------------
+# Module integration: bad_segments.save_results respects custom_proc
+# ---------------------------------------------------------------------------
+
+
+class TestBadSegmentsRespectsCustomProc:
+    """bad_segments.save_results redirects to deriv when custom_proc set."""
+
+    def test_save_writes_annotations_to_deriv(self, tmp_path, raw_meg):
+        from custom.preprocessing.bad_segments import BadSegmentsAnalysis
+
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = SimpleNamespace(
+            bids_root=str(bids_root),
+            deriv_root=str(tmp_path / "derivatives"),
+            subjects=["001"],
+            sessions=["01"],
+            task="restingstate",
+            ch_types=["mag"],
+            l_freq=0.1,
+            h_freq=30.0,
+            process_empty_room=False,
+            find_breaks=False,
+            n_jobs=1,
+            custom_proc="init",
+        )
+
+        # Add a bad annotation to verify it's written
+        raw_meg.set_annotations(
+            mne.Annotations(onset=[1.0], duration=[0.5], description=["BAD_test"])
+        )
+
+        analysis = BadSegmentsAnalysis(cfg)
+        results = {cfg.task: raw_meg, "bads": []}
+        analysis.save_results(results)
+
+        deriv_file = (
+            Path(cfg.deriv_root)
+            / "sub-001" / "ses-01" / "meg"
+            / "sub-001_ses-01_task-restingstate_proc-init_meg.fif"
+        )
+        assert deriv_file.exists()
+
+        # Read back and confirm the annotation is preserved
+        loaded = mne.io.read_raw_fif(deriv_file, preload=True)
+        descriptions = list(loaded.annotations.description)
+        assert any(d.startswith("BAD_test") for d in descriptions)
+
+
+# ---------------------------------------------------------------------------
+# load_data prefers deriv proc-* on subsequent steps
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataPrefersDeriv:
+    """Once a custom step has written to deriv proc-init, the next step
+    in the chain reads from there rather than re-reading bids_root."""
+
+    def test_apply_hfc_load_finds_deriv_after_first_step(
+        self, tmp_path, raw_meg
+    ):
+        from custom.preprocessing.apply_hfc import ApplyHFCAnalysis
+        from custom.preprocessing.bad_channels import BadChannelsAnalysis
+
+        bids_root = tmp_path / "bids"
+        bids_root.mkdir()
+        _write_minimal_raw_to_bids(bids_root, raw_meg, task="restingstate")
+
+        cfg = SimpleNamespace(
+            bids_root=str(bids_root),
+            deriv_root=str(tmp_path / "derivatives"),
+            subjects=["001"],
+            sessions=["01"],
+            task="restingstate",
+            ch_types=["mag"],
+            l_freq=1.0,
+            h_freq=100.0,
+            process_empty_room=False,
+            find_breaks=False,
+            n_jobs=1,
+            custom_proc="init",
+            _do_HFC=True,
+            _hfc_order=1,
+        )
+
+        # Step 1: bad_channels writes to deriv proc-init
+        analysis = BadChannelsAnalysis(cfg)
+        analysis.save_results({cfg.task: raw_meg, "bads": ["MEG001"]})
+
+        # Step 2: apply_hfc should now find the deriv proc-init file
+        hfc = ApplyHFCAnalysis(cfg)
+        data = hfc.load_data()
+
+        assert cfg.task in data
+        # The loaded raw should reflect the bads tagged by step 1
+        assert "MEG001" in data[cfg.task].info["bads"]
+
+
+# ---------------------------------------------------------------------------
+# noise + task ordering when custom_proc is set
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseTaskOrdering:
+    """When both noise and task are saved, noise must be saved first so the
+    task save can use its newly-written deriv path as the empty_room."""
+
+    @patch("custom.preprocessing.bad_channels.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.bad_channels.find_custom_input_paths")
+    def test_noise_saved_before_task(
+        self, mock_find, mock_write, raw_meg, tmp_path
+    ):
+        from custom.preprocessing.bad_channels import BadChannelsAnalysis
+
+        cfg = SimpleNamespace(
+            bids_root=str(tmp_path / "bids"),
+            deriv_root=str(tmp_path / "derivatives"),
+            subjects=["001"],
+            sessions=["01"],
+            task="restingstate",
+            ch_types=["mag"],
+            l_freq=1.0,
+            h_freq=100.0,
+            process_empty_room=True,
+            find_breaks=False,
+            n_jobs=1,
+            custom_proc="init",
+        )
+
+        noise_source_bp = MagicMock(name="noise_src")
+        task_source_bp = MagicMock(name="task_src")
+        noise_output_bp = MagicMock(name="noise_out")
+        task_output_bp = MagicMock(name="task_out")
+        # First find call is for noise, second for the task
+        mock_find.side_effect = [[noise_source_bp], [task_source_bp]]
+        mock_write.side_effect = [noise_output_bp, task_output_bp]
+
+        analysis = BadChannelsAnalysis(cfg)
+        results = {"noise": raw_meg, cfg.task: raw_meg, "bads": []}
+        analysis.save_results(results)
+
+        # Two writes, noise first, then task
+        assert mock_write.call_count == 2
+
+        # Task write should reference the noise output as its empty_room
+        task_call = mock_write.call_args_list[-1]
+        assert task_call.kwargs.get("empty_room") is noise_output_bp

--- a/tests/test_regress_full.py
+++ b/tests/test_regress_full.py
@@ -160,10 +160,10 @@ class TestRegressRun:
 
 class TestRegressLoadData:
     @patch("custom.preprocessing.regress.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.regress.mne_bids")
-    def test_load_single_task(self, mock_bids, mock_read, raw_meg, regress_cfg):
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
+    def test_load_single_task(self, mock_find, mock_read, raw_meg, regress_cfg):
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = RegressAnalysis(regress_cfg)
@@ -173,11 +173,11 @@ class TestRegressLoadData:
         mock_read.assert_called_once()
 
     @patch("custom.preprocessing.regress.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.regress.mne_bids")
-    def test_load_with_empty_room(self, mock_bids, mock_read, raw_meg, regress_cfg):
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
+    def test_load_with_empty_room(self, mock_find, mock_read, raw_meg, regress_cfg):
         regress_cfg.process_empty_room = True
         mock_bp = MagicMock()
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw_meg
 
         analysis = RegressAnalysis(regress_cfg)
@@ -186,9 +186,9 @@ class TestRegressLoadData:
         assert "noise" in data
         assert regress_cfg.task in data
 
-    @patch("custom.preprocessing.regress.mne_bids")
-    def test_load_no_files_raises(self, mock_bids, regress_cfg):
-        mock_bids.find_matching_paths.return_value = []
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
+    def test_load_no_files_raises(self, mock_find, regress_cfg):
+        mock_find.return_value = []
         analysis = RegressAnalysis(regress_cfg)
         with pytest.raises(FileNotFoundError):
             analysis.load_data()
@@ -199,12 +199,13 @@ class TestRegressLoadData:
 # ---------------------------------------------------------------------------
 
 class TestRegressSaveResults:
-    @patch("custom.preprocessing.regress.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.regress.mne_bids")
-    def test_save_writes_data(self, mock_bids, mock_write, raw_meg, regress_cfg):
+    @patch("custom.preprocessing.regress.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
+    def test_save_writes_data(self, mock_find, mock_write, raw_meg, regress_cfg):
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
+        mock_write.return_value = mock_bp
 
         analysis = RegressAnalysis(regress_cfg)
         results = {regress_cfg.task: raw_meg, "bads": []}
@@ -212,22 +213,25 @@ class TestRegressSaveResults:
 
         mock_write.assert_called_once()
 
-    @patch("custom.preprocessing.regress.mne_bids")
-    def test_save_no_paths_raises(self, mock_bids, raw_meg, regress_cfg):
-        mock_bids.find_matching_paths.return_value = []
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
+    def test_save_no_paths_raises(self, mock_find, raw_meg, regress_cfg):
+        mock_find.return_value = []
         analysis = RegressAnalysis(regress_cfg)
         results = {regress_cfg.task: raw_meg, "bads": []}
         with pytest.raises(FileNotFoundError):
             analysis.save_results(results)
 
-    @patch("custom.preprocessing.regress.write_raw_bids_preserve_events")
-    @patch("custom.preprocessing.regress.mne_bids")
+    @patch("custom.preprocessing.regress.write_raw_bids_custom_step")
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
     def test_save_with_empty_room_association(
-        self, mock_bids, mock_write, raw_meg, regress_cfg
+        self, mock_find, mock_write, raw_meg, regress_cfg
     ):
-        mock_bp = MagicMock()
-        mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        noise_bp = MagicMock(name="noise_bp")
+        task_bp = MagicMock(name="task_bp")
+        noise_bp.split = None
+        task_bp.split = None
+        mock_find.side_effect = [[noise_bp], [task_bp]]
+        mock_write.side_effect = [noise_bp, task_bp]
 
         analysis = RegressAnalysis(regress_cfg)
         results = {"noise": raw_meg, regress_cfg.task: raw_meg, "bads": []}
@@ -235,7 +239,7 @@ class TestRegressSaveResults:
 
         assert mock_write.call_count == 2
         task_call_kwargs = mock_write.call_args_list[-1][1]
-        assert "empty_room" in task_call_kwargs
+        assert task_call_kwargs.get("empty_room") is noise_bp
 
 
 # ---------------------------------------------------------------------------
@@ -249,17 +253,18 @@ class TestRegressModuleRun:
         captured = capsys.readouterr()
         assert "Disabled" in captured.out
 
-    @patch("custom.preprocessing.regress.write_raw_bids_preserve_events")
+    @patch("custom.preprocessing.regress.write_raw_bids_custom_step")
     @patch("custom.preprocessing.regress.read_raw_bids_with_retry")
-    @patch("custom.preprocessing.regress.mne_bids")
+    @patch("custom.preprocessing.regress.find_custom_input_paths")
     def test_run_end_to_end(
-        self, mock_bids, mock_read, mock_write, raw_with_ref_contamination, regress_cfg
+        self, mock_find, mock_read, mock_write, raw_with_ref_contamination, regress_cfg
     ):
         raw, _ = raw_with_ref_contamination
         mock_bp = MagicMock()
         mock_bp.split = None
-        mock_bids.find_matching_paths.return_value = [mock_bp]
+        mock_find.return_value = [mock_bp]
         mock_read.return_value = raw
+        mock_write.return_value = mock_bp
 
         run(regress_cfg)
 


### PR DESCRIPTION
This pull request introduces a new mechanism for routing custom preprocessing outputs in the BIDS pipeline, allowing intermediate results to be stored in the derivatives directory with a `proc-<label>` suffix instead of overwriting the original BIDS files. This is achieved through a new `custom_proc` configuration option and a set of helper functions for input/output file management. The changes are applied throughout the custom preprocessing modules to ensure that all steps can work with the new routing logic.

Key changes include:

**Custom preprocessing output routing:**

* Added a new `custom_proc` configuration option in `config-sample.py` to control whether custom preprocessing steps write results to the derivatives directory (`deriv_root`) with a `proc-<custom_proc>` suffix, or continue to overwrite the raw BIDS data files (legacy behavior).
* Implemented helper functions in `src/custom/preprocessing/_io.py` to support the new routing: `get_custom_proc`, `find_custom_input_paths`, `get_custom_output_path`, and `write_raw_bids_custom_step`. These functions manage reading from and writing to the appropriate locations based on the `custom_proc` setting. [[1]](diffhunk://#diff-f9d16d841dd4ec73893971909ca039bf0e465486148180fb234ed215fe755736R20-R34) [[2]](diffhunk://#diff-f9d16d841dd4ec73893971909ca039bf0e465486148180fb234ed215fe755736R248-R470)
* Updated the `mark_bad_channels_bids` function to use the new routing logic, allowing explicit control over which BIDSPath is marked and ensuring compatibility with the new output structure. [[1]](diffhunk://#diff-f9d16d841dd4ec73893971909ca039bf0e465486148180fb234ed215fe755736R558) [[2]](diffhunk://#diff-f9d16d841dd4ec73893971909ca039bf0e465486148180fb234ed215fe755736R575-R579) [[3]](diffhunk://#diff-f9d16d841dd4ec73893971909ca039bf0e465486148180fb234ed215fe755736L350-R607)

**Pipeline-wide adoption of new routing:**

* Refactored the `apply_hfc.py`, `bad_channels.py`, and `bad_segments.py` modules to use the new helper functions for finding input files and writing outputs, ensuring that all custom preprocessing steps honor the `custom_proc` configuration. This includes changes to data loading and saving logic throughout these modules. [[1]](diffhunk://#diff-06f8329d5de12f7d56d93c7e87a810acc58cad8a3888ebbdab57d7bfdf6b7166L64-R68) [[2]](diffhunk://#diff-06f8329d5de12f7d56d93c7e87a810acc58cad8a3888ebbdab57d7bfdf6b7166L111-R123) [[3]](diffhunk://#diff-06f8329d5de12f7d56d93c7e87a810acc58cad8a3888ebbdab57d7bfdf6b7166L186-R192) [[4]](diffhunk://#diff-a73876641551b6f7870296ae864db624ff3e338dbad902ad2b6fd6fbd502c86cL59-R63) [[5]](diffhunk://#diff-a73876641551b6f7870296ae864db624ff3e338dbad902ad2b6fd6fbd502c86cL116-R122) [[6]](diffhunk://#diff-a73876641551b6f7870296ae864db624ff3e338dbad902ad2b6fd6fbd502c86cL185-R219) [[7]](diffhunk://#diff-6e3b7f2b08e672da230f67bb8544347986fe7c3a7bf6c3444103990de05070dbL94-R98) [[8]](diffhunk://#diff-6e3b7f2b08e672da230f67bb8544347986fe7c3a7bf6c3444103990de05070dbL210-R214)

**API and import updates:**

* Exposed the new helper functions in the `__init__.py` of the custom preprocessing package for use throughout the codebase. [[1]](diffhunk://#diff-c1601d0c03a30936f22befe0337abdf833c1e4ad81872953cca6a86e78385d6fL57-R64) [[2]](diffhunk://#diff-c1601d0c03a30936f22befe0337abdf833c1e4ad81872953cca6a86e78385d6fR87-R90)

These changes provide a more robust and reproducible workflow for custom preprocessing by enabling intermediate outputs to be stored separately and reused in downstream steps, improving pipeline flexibility and traceability.