### PR TITLE
Add multi-detector consensus bad channel detection

### DIFF
--- a/docs/config-sample.py
+++ b/docs/config-sample.py
@@ -170,6 +170,27 @@ find_flat_channels_meg  = use_maxwell_filter
 find_noisy_channels_meg = use_maxwell_filter
 find_bad_channels_extra_kws = {'ignore_ref': True}
 
+# --- Custom automatic bad-channel detection (bad_channels step) ---
+# Detectors are combined by a consensus vote: a channel is auto-marked bad when
+# at least `_bad_channel_consensus_n` detectors agree.  Channels flagged by
+# fewer detectors are written to a *_badchannel-candidates.tsv sidecar and
+# surfaced (pre-highlighted) in the manual_channel step for confirmation.
+#   - 'gesd'         : full-recording GESD on per-channel std (whole-session bads)
+#   - 'timeresolved' : windowed GESD — catches INTERMITTENT bad channels
+#   - 'psd'          : OSL PSD / noise-floor outliers
+#   - 'lof'          : MNE Local Outlier Factor (spatial-neighbour outliers)
+_bad_channel_methods = ['gesd', 'timeresolved', 'psd', 'lof']
+_bad_channel_consensus_n = 2          # detectors that must agree to auto-mark bad
+                                      # (set to 1 to mark any flagged channel bad)
+_bad_channel_significance_level = 0.05  # GESD alpha (gesd + timeresolved + psd)
+_bad_channel_window_sec = 2.0         # time-resolved window length (seconds)
+_bad_channel_frac_threshold = 0.20    # flag if outlier in >20% of windows
+_bad_channel_psd_fmin = 1.0           # PSD detector frequency band (Hz)
+_bad_channel_psd_fmax = 100.0
+_bad_channel_psd_nfft = 2000          # PSD detector FFT length
+_bad_channel_lof_neighbors = 20       # LOF neighbours
+_bad_channel_lof_threshold = 1.5      # LOF threshold
+
 # Manual bad channel review step (run_channel.sh / run_preproc.sh)
 _manual_channels = True   # pause pipeline to inspect bad channels interactively
 

--- a/src/custom/preprocessing/bad_channels.py
+++ b/src/custom/preprocessing/bad_channels.py
@@ -1,14 +1,36 @@
 """Bad channel detection for OPM-MEG data.
 
-This module detects bad channels in raw MEG data using the Generalized
-Extreme Studentized Deviate (GESD) test from the OSL-ephys library.
-Bad channels are those with statistical properties significantly
-different from other channels, indicating sensor malfunction or
-poor contact.
+This module detects bad channels in raw MEG data by combining several
+complementary detectors and a configurable consensus vote.  The available
+detectors are:
 
-Detection is performed on bandpass-filtered data to focus on the
-frequency range of interest and avoid contamination from low-frequency
-drifts or high-frequency noise.
+* **gesd** (full-recording): the Generalized Extreme Studentized Deviate
+  (GESD) test from OSL-ephys, applied to each channel's standard deviation
+  computed over the whole recording.  Catches channels that are bad for the
+  entire session.
+* **timeresolved**: a windowed GESD test that flags channels which are
+  variance outliers in a sufficiently large *fraction* of short time windows.
+  This catches **intermittent** bad channels — channels that are only
+  disruptive for part of the recording and therefore have a near-normal
+  whole-recording standard deviation (these are typically what surface later
+  as single-channel ICA components).
+* **psd**: OSL-ephys' PSD/noise-floor detector, flagging channels with
+  abnormal spectra.
+* **lof**: MNE's Local Outlier Factor detector, flagging channels that are
+  anomalous relative to their spatial neighbours.
+
+Each enabled detector contributes a *vote* for a channel.  A channel is
+confirmed bad (marked ``status="bad"`` in ``channels.tsv`` and added to
+``raw.info['bads']``) when its vote count reaches ``_bad_channel_consensus_n``.
+Channels with at least one vote but fewer than the consensus threshold are
+written to a ``*_badchannel-candidates.tsv`` sidecar for manual confirmation
+in the ``manual_channel`` step, but are **not** removed automatically.
+
+Detection is performed on bandpass-filtered data (using the global
+``l_freq``/``h_freq``) to focus on the frequency range of interest and avoid
+contamination from low-frequency drifts or high-frequency noise.  The PSD
+detector runs on the unfiltered data so it can see the full spectrum / noise
+floor.
 
 Usage
 -----
@@ -37,21 +59,50 @@ Required:
     task : str
         Task name.
 
-Optional:
+Optional (with conservative defaults):
     process_empty_room : bool
         Also process empty room noise recording. Default: False.
+    _bad_channel_methods : list of str
+        Detectors to run. Default: ['gesd', 'timeresolved', 'psd', 'lof'].
+    _bad_channel_consensus_n : int
+        Number of detectors that must agree to auto-mark a channel bad.
+        Default: 2.  When set to 1, *any* flag marks a channel bad (and no
+        candidates are produced).
+    _bad_channel_significance_level : float
+        GESD significance level for the full-recording and time-resolved
+        detectors. Default: 0.05.
+    _bad_channel_window_sec : float
+        Window length (seconds) for the time-resolved detector. Default: 2.0.
+    _bad_channel_frac_threshold : float
+        Fraction of windows in which a channel must be an outlier for the
+        time-resolved detector to flag it. Default: 0.20.
+    _bad_channel_psd_fmin, _bad_channel_psd_fmax : float
+        Frequency band (Hz) for the PSD detector. Defaults: 1.0, 100.0.
+    _bad_channel_psd_nfft : int
+        FFT length for the PSD detector. Default: 2000.
+    _bad_channel_lof_neighbors : int
+        Number of neighbours for the LOF detector. Default: 20.
+    _bad_channel_lof_threshold : float
+        LOF threshold. Default: 1.5.
 
 Author: Harrison Ritz, 2025
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict
+from typing import Any, Dict, List, Set, Tuple
 
 import mne
+import numpy as np
+import pandas as pd
 
-from osl_ephys.preprocessing.osl_wrappers import bad_channels as osl_bad_channels
+from osl_ephys.preprocessing.osl_wrappers import (
+    bad_channels as osl_bad_channels,
+    detect_bad_channels_psd as osl_detect_bad_channels_psd,
+    gesd as osl_gesd,
+)
 
 import mne_bids
 
@@ -63,17 +114,56 @@ from ._io import (
 )
 
 
+# Default detectors and consensus parameters.
+_DEFAULT_METHODS: List[str] = ["gesd", "timeresolved", "psd", "lof"]
+_DEFAULT_CONSENSUS_N: int = 2
+_DEFAULT_SIGNIFICANCE: float = 0.05
+_DEFAULT_WINDOW_SEC: float = 2.0
+_DEFAULT_FRAC_THRESHOLD: float = 0.20
+_DEFAULT_PSD_FMIN: float = 1.0
+_DEFAULT_PSD_FMAX: float = 100.0
+_DEFAULT_PSD_NFFT: int = 2000
+_DEFAULT_LOF_NEIGHBORS: int = 20
+_DEFAULT_LOF_THRESHOLD: float = 1.5
+
+# Suffix used for the per-recording candidates sidecar.
+_CANDIDATES_SUFFIX = "_badchannel-candidates.tsv"
+
+
+def candidates_sidecar_path(bids_path: mne_bids.BIDSPath) -> Path:
+    """Return the candidates-TSV path that pairs with a given BIDSPath.
+
+    The sidecar lives next to the (output) data file and is named after the
+    BIDS basename so that downstream steps (e.g. ``manual_channel``) can locate
+    it from their own input path.
+
+    Parameters
+    ----------
+    bids_path : mne_bids.BIDSPath
+        Path of the data file the candidates relate to.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the ``*_badchannel-candidates.tsv`` sidecar.
+    """
+    return Path(bids_path.directory) / f"{bids_path.basename}{_CANDIDATES_SUFFIX}"
+
+
 class BadChannelsAnalysis(BaseAnalysis):
-    """Detect bad channels using statistical methods.
+    """Detect bad channels via a consensus of complementary detectors.
 
-    Uses GESD (Generalized Extreme Studentized Deviate) test to identify
-    channels that are statistical outliers compared to other channels.
-    This is robust to multiple outliers and doesn't assume a specific
-    distribution of the data.
+    Runs the enabled detectors (full-recording GESD, time-resolved GESD, PSD
+    noise-floor, and LOF), tallies a vote per channel, and splits the result
+    into *confirmed* bad channels (vote count >= consensus threshold) and
+    *candidate* bad channels (>= 1 vote but below the threshold).  Confirmed
+    channels are marked bad in BIDS; candidates are written to a sidecar for
+    manual review.
 
-    When processing multiple tasks (e.g., main task + noise), bad channels
-    are detected separately but the union of all detected bad channels is
-    marked in all recordings.
+    When processing multiple tasks (e.g. main task + noise), votes are tallied
+    per recording and the union of confirmed channels is marked in all
+    recordings; the union of candidates (excluding confirmed) is written to the
+    sidecar.
 
     Attributes
     ----------
@@ -84,7 +174,9 @@ class BadChannelsAnalysis(BaseAnalysis):
 
     See Also
     --------
-    osl_ephys.preprocessing.osl_wrappers.bad_channels : OSL detection function.
+    osl_ephys.preprocessing.osl_wrappers.bad_channels : OSL GESD detection.
+    osl_ephys.preprocessing.osl_wrappers.detect_bad_channels_psd : PSD detector.
+    mne.preprocessing.find_bad_channels_lof : Local Outlier Factor detector.
     """
 
     ANALYSIS_KEY = "badchannels"
@@ -99,6 +191,29 @@ class BadChannelsAnalysis(BaseAnalysis):
             Always True (no config flag required for this analysis).
         """
         return True
+
+    # ------------------------------------------------------------------
+    # Parameter helpers
+    # ------------------------------------------------------------------
+
+    def _methods(self) -> List[str]:
+        """Return the list of enabled detectors (lower-cased)."""
+        methods = getattr(self.cfg, "_bad_channel_methods", None) or _DEFAULT_METHODS
+        return [str(m).lower() for m in methods]
+
+    def _consensus_n(self) -> int:
+        """Return the consensus vote threshold (>= 1)."""
+        return max(1, int(getattr(self.cfg, "_bad_channel_consensus_n", _DEFAULT_CONSENSUS_N)))
+
+    def _significance(self) -> float:
+        """Return the GESD significance level."""
+        return float(
+            getattr(self.cfg, "_bad_channel_significance_level", _DEFAULT_SIGNIFICANCE)
+        )
+
+    # ------------------------------------------------------------------
+    # BaseAnalysis interface
+    # ------------------------------------------------------------------
 
     def load_data(self) -> Dict[str, Any]:
         """Load raw data for bad channel detection.
@@ -130,10 +245,7 @@ class BadChannelsAnalysis(BaseAnalysis):
         return data
 
     def run(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute bad channel detection on all loaded data.
-
-        Detects bad channels in each task separately, then creates a
-        union of all detected bad channels.
+        """Run all detectors on each task and combine via consensus voting.
 
         Parameters
         ----------
@@ -143,41 +255,73 @@ class BadChannelsAnalysis(BaseAnalysis):
         Returns
         -------
         results : dict
-            Dictionary with raw data per task and 'bads' key containing
-            the union of all detected bad channels.
+            Dictionary with raw data per task plus:
+              * ``bads`` : sorted list of confirmed bad channels (union).
+              * ``bad_methods`` : {channel -> sorted method list} for confirmed.
+              * ``candidates`` : {channel -> sorted method list} for candidates.
         """
+        consensus_n = self._consensus_n()
+        self.log(
+            f"Detectors={self._methods()} | consensus_n={consensus_n} | "
+            f"significance={self._significance()}"
+        )
+
         results: Dict[str, Any] = {}
-        all_bads: set[str] = set()
+        confirmed_methods: Dict[str, Set[str]] = {}
+        candidate_methods: Dict[str, Set[str]] = {}
 
         for task, raw in data.items():
             self.log(f"Processing task={task}")
-            bads = self._detect_bad_channels(raw)
-            results[task] = raw
-            all_bads.update(bads)
+            method_results = self._detect_all_methods(raw)
+            confirmed, candidates = self._combine_votes(method_results, consensus_n)
 
-        results["bads"] = sorted(all_bads)
-        self.log(f"Total unique bad channels: {len(results['bads'])}")
+            for ch, methods in confirmed.items():
+                confirmed_methods.setdefault(ch, set()).update(methods)
+            for ch, methods in candidates.items():
+                candidate_methods.setdefault(ch, set()).update(methods)
+
+            results[task] = raw
+
+        # A channel confirmed in any recording outranks a candidacy elsewhere.
+        for ch in confirmed_methods:
+            candidate_methods.pop(ch, None)
+
+        results["bads"] = sorted(confirmed_methods)
+        results["bad_methods"] = {
+            ch: sorted(m) for ch, m in confirmed_methods.items()
+        }
+        results["candidates"] = {
+            ch: sorted(m) for ch, m in candidate_methods.items()
+        }
+
+        self.log(
+            f"Confirmed bad channels: {len(results['bads'])} "
+            f"({results['bads']}); candidates: {len(results['candidates'])} "
+            f"({sorted(results['candidates'])})"
+        )
 
         return results
 
     def save_results(self, results: Dict[str, Any]) -> None:
-        """Save results with bad channel markings.
-
-        Updates raw data info['bads'] with newly detected channels
-        (merged with existing bad channels) and writes to BIDS.
+        """Save results: mark confirmed bads in BIDS, write candidates sidecar.
 
         Parameters
         ----------
         results : dict
-            Dictionary with raw data per task and 'bads' list.
+            Output of :meth:`run`.
         """
         self.log("Saving results...")
 
-        # Get detected bad channels
-        unique_bads = sorted(set(results.get("bads", []))) if results.get("bads") else []
+        confirmed = sorted(set(results.get("bads", []) or []))
+        bad_methods: Dict[str, List[str]] = results.get("bad_methods", {}) or {}
+        candidates: Dict[str, List[str]] = results.get("candidates", {}) or {}
 
         # Separate task data from metadata
-        tasks = {k: v for k, v in results.items() if k not in {"bads"}}
+        tasks = {
+            k: v
+            for k, v in results.items()
+            if k not in {"bads", "bad_methods", "candidates"}
+        }
 
         # Process noise FIRST (when present) so the task save can use the
         # already-written noise as its empty-room association.
@@ -191,11 +335,11 @@ class BadChannelsAnalysis(BaseAnalysis):
 
             source_bp = paths[0]
 
-            # Merge existing and newly detected bad channels into raw.info,
+            # Merge existing and newly confirmed bad channels into raw.info,
             # which write_raw_bids will reflect in the output channels.tsv.
-            if unique_bads:
+            if confirmed:
                 existing_bads = raw.info.get("bads", [])
-                merged_bads = sorted(set(existing_bads) | set(unique_bads))
+                merged_bads = sorted(set(existing_bads) | set(confirmed))
                 raw.info["bads"] = merged_bads
                 self.log(f"task={task}: {len(merged_bads)} total bad channels")
 
@@ -204,58 +348,267 @@ class BadChannelsAnalysis(BaseAnalysis):
                 raw, self.cfg, source_bp, empty_room=empty_room
             )
 
-            # Tag the new bad channels with description="osl" in the
-            # channels.tsv that write_raw_bids just produced.
-            if unique_bads:
+            # Tag the confirmed bad channels in channels.tsv with a per-channel
+            # description recording which detectors agreed (e.g. "auto:gesd+lof").
+            if confirmed:
+                descriptions = [
+                    "auto:" + "+".join(bad_methods.get(ch, ["auto"]))
+                    for ch in confirmed
+                ]
                 mne_bids.mark_channels(
                     bids_path=output_bp,
-                    ch_names=unique_bads,
+                    ch_names=confirmed,
                     status="bad",
-                    descriptions="osl",
+                    descriptions=descriptions,
                 )
+
+            # Write the candidates sidecar next to the output for manual review.
+            self._write_candidates_sidecar(output_bp, candidates)
 
             if task == "noise":
                 er_output_bp = output_bp
 
             self.log(f"Saved task={task} → {output_bp.fpath}")
 
-    def _detect_bad_channels(self, raw: mne.io.BaseRaw) -> list[str]:
-        """Detect bad channels in raw data.
+    # ------------------------------------------------------------------
+    # Consensus combination
+    # ------------------------------------------------------------------
 
-        Applies bandpass filtering before detection to focus on the
-        frequency range of interest.
+    def _combine_votes(
+        self, method_results: Dict[str, Set[str]], consensus_n: int
+    ) -> Tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
+        """Tally per-channel votes and split confirmed vs candidate channels.
+
+        Parameters
+        ----------
+        method_results : dict
+            {method_name -> set of flagged channel names}.
+        consensus_n : int
+            Number of agreeing detectors required to confirm a channel.
+
+        Returns
+        -------
+        confirmed : dict
+            {channel -> set of methods} for channels with >= consensus_n votes.
+        candidates : dict
+            {channel -> set of methods} for channels with 1 <= votes < consensus_n.
+        """
+        votes: Dict[str, Set[str]] = {}
+        for method, chans in method_results.items():
+            for ch in chans:
+                votes.setdefault(ch, set()).add(method)
+
+        confirmed: Dict[str, Set[str]] = {}
+        candidates: Dict[str, Set[str]] = {}
+        for ch, methods in votes.items():
+            if len(methods) >= consensus_n:
+                confirmed[ch] = methods
+            else:
+                candidates[ch] = methods
+
+        return confirmed, candidates
+
+    def _write_candidates_sidecar(
+        self, output_bp: mne_bids.BIDSPath, candidates: Dict[str, List[str]]
+    ) -> None:
+        """Write (or clear) the candidates TSV sidecar for one recording.
+
+        Parameters
+        ----------
+        output_bp : mne_bids.BIDSPath
+            Path the recording was written to.
+        candidates : dict
+            {channel -> list of methods} for candidate channels.
+        """
+        try:
+            sidecar = candidates_sidecar_path(output_bp)
+        except (TypeError, ValueError):  # e.g. non-filesystem BIDSPath in tests
+            return
+
+        if not candidates:
+            # Remove any stale sidecar from a previous run so it doesn't mislead.
+            if sidecar.exists():
+                sidecar.unlink()
+            return
+
+        rows = [
+            {
+                "channel": ch,
+                "n_votes": len(methods),
+                "methods": "+".join(sorted(methods)),
+            }
+            for ch, methods in sorted(candidates.items())
+        ]
+        pd.DataFrame(rows).to_csv(sidecar, sep="\t", index=False)
+        self.log(
+            f"Wrote {len(rows)} candidate channel(s) for manual review → {sidecar}"
+        )
+
+    # ------------------------------------------------------------------
+    # Detectors
+    # ------------------------------------------------------------------
+
+    def _detect_all_methods(self, raw: mne.io.BaseRaw) -> Dict[str, Set[str]]:
+        """Run all enabled detectors on a single recording.
 
         Parameters
         ----------
         raw : mne.io.BaseRaw
-            Raw data to analyze.
+            Raw data to analyse.
 
         Returns
         -------
-        bads : list of str
-            List of bad channel names.
+        method_results : dict
+            {method_name -> set of flagged channel names}.  Detectors that are
+            disabled, unavailable, or error out contribute an empty set.
         """
-        self.log(
-            f"Detecting bad channels (filter: {self.cfg.l_freq}-{self.cfg.h_freq} Hz)"
-        )
+        picks = self.cfg.ch_types[0]
+        methods = self._methods()
 
-        # Filter before detection
+        # Bandpass-filtered copy for the variance/spatial detectors (the PSD
+        # detector deliberately runs on the unfiltered data, see below).
         filt = raw.copy().filter(
             l_freq=self.cfg.l_freq, h_freq=self.cfg.h_freq, method="iir"
         )
 
-        # Run GESD detection
-        detected = osl_bad_channels(
-            filt,
-            picks=self.cfg.ch_types[0],
-            significance_level=0.05,
-        )
-
-        bads = list(detected.info["bads"])
-        self.log(f"Detected {len(bads)} bad channels: {bads}")
+        results: Dict[str, Set[str]] = {}
+        if "gesd" in methods:
+            results["gesd"] = self._detect_gesd_full(filt, picks)
+        if "timeresolved" in methods:
+            results["timeresolved"] = self._detect_timeresolved(filt, picks)
+        if "psd" in methods:
+            results["psd"] = self._detect_psd(raw)
+        if "lof" in methods:
+            results["lof"] = self._detect_lof(filt, picks)
 
         del filt
-        return bads
+
+        # Channels already marked bad upstream stay bad regardless (preserved in
+        # save_results); exclude them so the vote tally reflects only newly
+        # detected channels.
+        existing = set(raw.info.get("bads", []))
+        results = {m: (chans - existing) for m, chans in results.items()}
+
+        for method, chans in results.items():
+            self.log(f"  [{method}] flagged {len(chans)}: {sorted(chans)}")
+
+        return results
+
+    def _detect_gesd_full(self, filt: mne.io.BaseRaw, picks: str) -> Set[str]:
+        """Full-recording GESD on per-channel std (OSL-ephys)."""
+        try:
+            detected = osl_bad_channels(
+                filt.copy(),
+                picks=picks,
+                significance_level=self._significance(),
+            )
+            return set(detected.info["bads"])
+        except Exception as exc:  # pragma: no cover - defensive
+            self.log(f"  [gesd] skipped ({exc})")
+            return set()
+
+    def _detect_timeresolved(self, filt: mne.io.BaseRaw, picks: str) -> Set[str]:
+        """Windowed GESD: flag channels that are variance outliers in many windows.
+
+        The recording is split into non-overlapping windows.  Within each
+        window we GESD the per-channel standard deviation (upper tail only —
+        only abnormally *high* variance counts as bad) and tally how often each
+        channel is flagged.  Channels flagged in more than
+        ``_bad_channel_frac_threshold`` of windows are returned.
+        """
+        window_sec = float(
+            getattr(self.cfg, "_bad_channel_window_sec", _DEFAULT_WINDOW_SEC)
+        )
+        frac_threshold = float(
+            getattr(self.cfg, "_bad_channel_frac_threshold", _DEFAULT_FRAC_THRESHOLD)
+        )
+        alpha = self._significance()
+
+        ch_idx = np.array(
+            mne.pick_types(filt.info, meg=picks, ref_meg=False, exclude="bads")
+        )
+        if ch_idx.size < 3:
+            self.log("  [timeresolved] too few channels; skipping")
+            return set()
+        names = np.array(filt.ch_names)[ch_idx]
+
+        # Drop already-annotated bad spans so they don't dominate the metric.
+        data = filt.get_data(picks=ch_idx, reject_by_annotation="omit")
+        n_ch, n_times = data.shape
+
+        win = max(1, int(round(filt.info["sfreq"] * window_sec)))
+        n_windows = n_times // win
+        if n_windows < 2:
+            self.log(
+                f"  [timeresolved] only {n_windows} full window(s); skipping"
+            )
+            return set()
+
+        # Per-channel std in each full window → (n_ch, n_windows).
+        trimmed = data[:, : n_windows * win].reshape(n_ch, n_windows, win)
+        win_std = trimmed.std(axis=2)
+
+        flag_counts = np.zeros(n_ch, dtype=int)
+        for w in range(n_windows):
+            mask, _ = osl_gesd(win_std[:, w], alpha=alpha, p_out=0.5, outlier_side=1)
+            flag_counts += np.asarray(mask, dtype=int)
+
+        frac = flag_counts / n_windows
+        bad = set(names[frac > frac_threshold].tolist())
+        if bad:
+            for ch in sorted(bad):
+                idx = int(np.where(names == ch)[0][0])
+                self.log(
+                    f"    {ch}: outlier in {frac[idx] * 100:.0f}% of "
+                    f"{n_windows} windows"
+                )
+        return bad
+
+    def _detect_psd(self, raw: mne.io.BaseRaw) -> Set[str]:
+        """PSD / noise-floor detector (OSL-ephys), run on unfiltered data."""
+        fmin = float(getattr(self.cfg, "_bad_channel_psd_fmin", _DEFAULT_PSD_FMIN))
+        fmax = float(getattr(self.cfg, "_bad_channel_psd_fmax", _DEFAULT_PSD_FMAX))
+        n_fft = int(getattr(self.cfg, "_bad_channel_psd_nfft", _DEFAULT_PSD_NFFT))
+        try:
+            bads = osl_detect_bad_channels_psd(
+                raw.copy(),
+                fmin=fmin,
+                fmax=fmax,
+                n_fft=n_fft,
+                alpha=self._significance(),
+            )
+            return set(bads)
+        except Exception as exc:
+            self.log(f"  [psd] skipped ({exc})")
+            return set()
+
+    def _detect_lof(self, filt: mne.io.BaseRaw, picks: str) -> Set[str]:
+        """Local Outlier Factor detector (MNE), comparing spatial neighbours."""
+        n_neighbors = int(
+            getattr(self.cfg, "_bad_channel_lof_neighbors", _DEFAULT_LOF_NEIGHBORS)
+        )
+        threshold = float(
+            getattr(self.cfg, "_bad_channel_lof_threshold", _DEFAULT_LOF_THRESHOLD)
+        )
+        n_good = len(
+            mne.pick_types(filt.info, meg=picks, ref_meg=False, exclude="bads")
+        )
+        if n_good < 3:
+            self.log("  [lof] too few channels; skipping")
+            return set()
+        # n_neighbors must be < number of channels considered.
+        n_neighbors = min(n_neighbors, n_good - 1)
+        try:
+            bads = mne.preprocessing.find_bad_channels_lof(
+                filt,
+                n_neighbors=n_neighbors,
+                picks=picks,
+                threshold=threshold,
+            )
+            return set(bads)
+        except Exception as exc:
+            self.log(f"  [lof] skipped ({exc})")
+            return set()
 
 
 def run(cfg: SimpleNamespace) -> None:

--- a/src/custom/preprocessing/manual_channel.py
+++ b/src/custom/preprocessing/manual_channel.py
@@ -60,7 +60,10 @@ import mne
 
 import mne_bids
 
+import pandas as pd
+
 from ._base import BaseAnalysis, have_qt_browser
+from .bad_channels import candidates_sidecar_path
 from ._io import (
     find_custom_input_paths,
     read_raw_bids_with_retry,
@@ -150,8 +153,12 @@ class ManualChannelAnalysis(BaseAnalysis):
         raw = data[self.cfg.task]
         noise = data.get("noise")
 
+        # Surface automatic bad-channel *candidates* (channels flagged by a
+        # single detector in the bad_channels step) for confirmation.
+        candidates = self._load_candidates()
+
         # Run interactive selection
-        raw, bads, noise = self._manual_channel_selection(raw, noise)
+        raw, bads, noise = self._manual_channel_selection(raw, noise, candidates)
 
         results[self.cfg.task] = raw
         results["bads"] = bads
@@ -210,10 +217,42 @@ class ManualChannelAnalysis(BaseAnalysis):
 
             self.log(f"Saved task={task} → {output_bp.fpath}")
 
+    def _load_candidates(self) -> list[str]:
+        """Read bad-channel candidates written by the bad_channels step.
+
+        Returns
+        -------
+        candidates : list of str
+            Channel names flagged as candidates (single-detector hits) for the
+            main task, or an empty list if no sidecar exists.
+        """
+        paths = find_custom_input_paths(self.cfg, task=self.cfg.task)
+        if not paths:
+            return []
+
+        sidecar = candidates_sidecar_path(paths[0])
+        if not sidecar.exists():
+            return []
+
+        try:
+            df = pd.read_csv(sidecar, sep="\t")
+            candidates = [str(ch) for ch in df["channel"].tolist()]
+        except Exception as exc:  # pragma: no cover - defensive
+            self.log(f"Could not read candidates sidecar {sidecar}: {exc}")
+            return []
+
+        if candidates:
+            self.log(
+                f"{len(candidates)} bad-channel candidate(s) for review "
+                f"(from {sidecar.name}): {candidates}"
+            )
+        return candidates
+
     def _manual_channel_selection(
         self,
         raw: mne.io.BaseRaw,
         noise: mne.io.BaseRaw | None = None,
+        candidates: list[str] | None = None,
     ) -> tuple[mne.io.BaseRaw, list[str], mne.io.BaseRaw | None]:
         """Interactive manual selection of bad channels.
 
@@ -227,6 +266,12 @@ class ManualChannelAnalysis(BaseAnalysis):
             Raw data for channel inspection.
         noise : mne.io.BaseRaw or None
             Optional noise data to apply same markings.
+        candidates : list of str or None
+            Automatic bad-channel candidates to pre-highlight in the browser so
+            the user can confirm (leave marked) or reject (unmark) them.  Only
+            pre-marked when the interactive browser is actually shown; if the
+            browser is unavailable the candidates are left untouched so they are
+            not silently confirmed.
 
         Returns
         -------
@@ -237,12 +282,29 @@ class ManualChannelAnalysis(BaseAnalysis):
         noise : mne.io.BaseRaw or None
             Noise data with same bad channels (if provided).
         """
+        candidates = candidates or []
+
         if not have_qt_browser():
             self.log(
                 "Qt browser not available; skipping interactive plot "
                 "(set SKIP_MANUAL=1 to suppress this message)"
             )
+            if candidates:
+                self.log(
+                    f"{len(candidates)} candidate(s) left unconfirmed "
+                    "(no interactive browser to review them)"
+                )
         else:
+            # Pre-highlight candidates as bad so they show up flagged in the
+            # browser; the user confirms by leaving them or rejects by clicking.
+            present = [ch for ch in candidates if ch in raw.ch_names]
+            if present:
+                raw.info["bads"] = sorted(set(raw.info["bads"]) | set(present))
+                self.log(
+                    f"Pre-highlighting {len(present)} candidate(s) for "
+                    f"confirmation: {present}"
+                )
+
             self.log("Opening interactive plot for channel inspection")
             self.log("Instructions: Click on channels to mark as bad, then close window")
 

--- a/tests/test_bad_channels.py
+++ b/tests/test_bad_channels.py
@@ -1,8 +1,10 @@
-"""Tests for bad_channels.py — GESD bad channel detection.
+"""Tests for bad_channels.py — multi-detector consensus bad channel detection.
 
-Exercises the core detection logic (_detect_bad_channels), the run()
-accumulation across tasks, and the module-level run(cfg) entry point.
-BIDS I/O is mocked; the statistical detection itself runs on synthetic data.
+Exercises the individual detectors (full-recording GESD, time-resolved GESD,
+PSD, LOF), the consensus vote that splits confirmed vs candidate channels, the
+candidates sidecar, the run() accumulation across tasks, and the module-level
+run(cfg) entry point.  BIDS I/O is mocked; the statistical detection itself runs
+on synthetic data.
 """
 
 from __future__ import annotations
@@ -14,7 +16,11 @@ import mne
 import numpy as np
 import pytest
 
-from custom.preprocessing.bad_channels import BadChannelsAnalysis, run
+from custom.preprocessing.bad_channels import (
+    BadChannelsAnalysis,
+    candidates_sidecar_path,
+    run,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -40,29 +46,30 @@ def bad_ch_cfg(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _detect_bad_channels — core GESD logic
+# Detectors — core per-recording logic
 # ---------------------------------------------------------------------------
 
 class TestDetectBadChannels:
-    """Test the core detection method on synthetic data."""
+    """Test the detectors on synthetic data."""
 
     def test_detects_bad_channel_with_high_variance(
         self, raw_with_bad_channel, bad_ch_cfg
     ):
-        """A channel with 100x higher variance should be flagged."""
+        """A channel with 100x higher variance should be flagged by detectors."""
         analysis = BadChannelsAnalysis(bad_ch_cfg)
-        bads = analysis._detect_bad_channels(raw_with_bad_channel)
-        assert isinstance(bads, list)
-        # MEG001 has 100x variance — GESD should detect it
-        assert "MEG001" in bads
+        results = analysis._detect_all_methods(raw_with_bad_channel)
+        flagged = set().union(*results.values()) if results else set()
+        # MEG001 has 100x variance — multiple detectors should catch it
+        assert "MEG001" in flagged
+        assert "gesd" in results and "MEG001" in results["gesd"]
 
-    def test_clean_data_has_few_or_no_bads(self, raw_meg, bad_ch_cfg):
-        """Homogeneous random data should flag few or no channels."""
+    def test_clean_data_has_few_or_no_confirmed_bads(self, raw_meg, bad_ch_cfg):
+        """Homogeneous random data should yield no confirmed (consensus) bads."""
         analysis = BadChannelsAnalysis(bad_ch_cfg)
-        bads = analysis._detect_bad_channels(raw_meg)
-        assert isinstance(bads, list)
-        # With iid Gaussian channels, we expect 0 or very few detections
-        assert len(bads) <= 2
+        results = analysis._detect_all_methods(raw_meg)
+        confirmed, _ = analysis._combine_votes(results, analysis._consensus_n())
+        # Consensus of >=2 detectors on iid data should confirm nothing.
+        assert len(confirmed) == 0
 
     def test_filtering_applied_before_detection(
         self, raw_with_bad_channel, bad_ch_cfg
@@ -72,8 +79,150 @@ class TestDetectBadChannels:
         bad_ch_cfg.h_freq = 40.0
         analysis = BadChannelsAnalysis(bad_ch_cfg)
         # Should not crash, and still detect the outlier
-        bads = analysis._detect_bad_channels(raw_with_bad_channel)
-        assert isinstance(bads, list)
+        results = analysis._detect_all_methods(raw_with_bad_channel)
+        flagged = set().union(*results.values()) if results else set()
+        assert "MEG001" in flagged
+
+
+# ---------------------------------------------------------------------------
+# Time-resolved detector — intermittent bad channels
+# ---------------------------------------------------------------------------
+
+class TestTimeResolvedDetection:
+    """The time-resolved detector should catch intermittent bad channels."""
+
+    def _make_intermittent(self, meg_info, bad_frac=0.3):
+        """Raw where MEG002 is bad in only `bad_frac` of the recording."""
+        rng = np.random.RandomState(7)
+        n_ch = len(meg_info["ch_names"])
+        n_samples = int(meg_info["sfreq"] * 60)  # 60 s → many windows
+        data = rng.randn(n_ch, n_samples) * 1e-13
+        # Inflate MEG002 variance in a contiguous early fraction of the record.
+        bad_stop = int(bad_frac * n_samples)
+        data[2, :bad_stop] *= 80.0
+        return mne.io.RawArray(data, meg_info)
+
+    def test_timeresolved_catches_intermittent(self, meg_info, bad_ch_cfg):
+        """A channel bad in ~30% of windows is flagged by time-resolved."""
+        bad_ch_cfg.l_freq = 1.0
+        bad_ch_cfg.h_freq = 100.0
+        raw = self._make_intermittent(meg_info, bad_frac=0.3)
+
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        filt = raw.copy().filter(l_freq=1.0, h_freq=100.0, method="iir")
+        tr = analysis._detect_timeresolved(filt, "mag")
+        assert "MEG002" in tr
+
+    def _make_heterogeneous_intermittent(self, bad_frac=0.3):
+        """Raw with a realistic spread of channel noise levels, plus an
+        intermittent channel whose whole-recording variance hides in the pack.
+
+        Real OPM arrays have heterogeneous per-channel noise floors.  A channel
+        that is only intermittently disruptive has a whole-recording std that
+        sits within that natural spread (so full-recording GESD misses it), yet
+        in its bad windows it transiently exceeds even the noisiest channels (so
+        the time-resolved detector catches it).
+        """
+        n_meg = 40
+        info = mne.create_info(
+            [f"MEG{i:03d}" for i in range(n_meg)], sfreq=300.0, ch_types="mag"
+        )
+        rng = np.random.RandomState(11)
+        n_samples = int(info["sfreq"] * 60)
+        # Smoothly varying baseline noise levels — no static outlier channel.
+        scales = np.linspace(1.0, 3.0, n_meg)
+        data = rng.randn(n_meg, n_samples) * scales[:, None] * 1e-13
+        # MEG002 is a quiet channel (low baseline) that misbehaves intermittently.
+        data[2, :] = rng.randn(n_samples) * 1e-13
+        win = int(info["sfreq"] * 2.0)
+        n_windows = n_samples // win
+        bad_windows = rng.choice(
+            n_windows, size=int(bad_frac * n_windows), replace=False
+        )
+        for w in bad_windows:
+            data[2, w * win:(w + 1) * win] *= 6.0
+        return mne.io.RawArray(data, info)
+
+    def test_full_gesd_misses_intermittent(self, bad_ch_cfg):
+        """Whole-recording GESD misses the intermittent channel that the
+        time-resolved detector catches (the core motivation)."""
+        raw = self._make_heterogeneous_intermittent(bad_frac=0.3)
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        filt = raw.copy().filter(l_freq=1.0, h_freq=100.0, method="iir")
+        full = analysis._detect_gesd_full(filt, "mag")
+        tr = analysis._detect_timeresolved(filt, "mag")
+        # The time-resolved detector catches it even when full-recording does not.
+        assert "MEG002" in tr
+        assert "MEG002" not in full
+
+
+# ---------------------------------------------------------------------------
+# Consensus voting
+# ---------------------------------------------------------------------------
+
+class TestConsensusVoting:
+    """Test _combine_votes confirmed/candidate split."""
+
+    def test_consensus_two_confirms_multi_method(self, bad_ch_cfg):
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        method_results = {
+            "gesd": {"MEG001"},
+            "timeresolved": {"MEG001"},
+            "lof": {"MEG005"},  # single method only
+        }
+        confirmed, candidates = analysis._combine_votes(method_results, 2)
+        assert "MEG001" in confirmed
+        assert "MEG005" in candidates
+        assert "MEG005" not in confirmed
+        assert "MEG001" not in candidates
+
+    def test_consensus_one_marks_any_flag(self, bad_ch_cfg):
+        """With consensus_n=1, any single flag confirms (no candidates)."""
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        method_results = {"lof": {"MEG005"}}
+        confirmed, candidates = analysis._combine_votes(method_results, 1)
+        assert "MEG005" in confirmed
+        assert candidates == {}
+
+
+# ---------------------------------------------------------------------------
+# Candidates sidecar — written here, consumed by manual_channel
+# ---------------------------------------------------------------------------
+
+class TestCandidatesSidecar:
+    """Single-method flags are written to a sidecar and not auto-marked."""
+
+    def test_sidecar_written_and_readable(self, tmp_path, bad_ch_cfg):
+        """_write_candidates_sidecar writes a TSV that manual_channel can read."""
+        # Lightweight stand-in for a BIDSPath with directory + basename.
+        fake_bp = SimpleNamespace(
+            directory=str(tmp_path),
+            basename="sub-001_ses-01_task-restingstate_meg",
+        )
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        analysis._write_candidates_sidecar(
+            fake_bp, {"MEG004": ["lof"], "MEG006": ["psd"]}
+        )
+
+        sidecar = candidates_sidecar_path(fake_bp)
+        assert sidecar.exists()
+
+        import pandas as pd
+        df = pd.read_csv(sidecar, sep="\t")
+        assert set(df["channel"]) == {"MEG004", "MEG006"}
+
+    def test_empty_candidates_removes_stale_sidecar(self, tmp_path, bad_ch_cfg):
+        """An empty candidate set clears any stale sidecar from a prior run."""
+        fake_bp = SimpleNamespace(
+            directory=str(tmp_path),
+            basename="sub-001_ses-01_task-restingstate_meg",
+        )
+        analysis = BadChannelsAnalysis(bad_ch_cfg)
+        analysis._write_candidates_sidecar(fake_bp, {"MEG004": ["lof"]})
+        assert candidates_sidecar_path(fake_bp).exists()
+
+        analysis._write_candidates_sidecar(fake_bp, {})
+        assert not candidates_sidecar_path(fake_bp).exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Intermittent bad channels — bad for only part of a recording — slip past the whole-recording GESD std test and surface downstream as single-channel ICA components. This adds complementary detectors and a consensus vote to the bad_channels step so these channels are caught conservatively.

Detectors (each casts a vote per channel):
  - gesd:         full-recording GESD on per-channel std (existing; kept)
  - timeresolved: windowed GESD flagging channels that are variance outliers
                  in >frac_threshold of short windows (catches intermittent)
  - psd:          OSL PSD / noise-floor outliers (previously unused)
  - lof:          MNE Local Outlier Factor (spatial-neighbour outliers)

Consensus marking:
  - channels with >= _bad_channel_consensus_n votes are auto-marked bad (channels.tsv description records the agreeing detectors)
  - channels with fewer votes are written to a *_badchannel-candidates.tsv sidecar and pre-highlighted in the manual_channel step for confirmation, not auto-removed (consensus_n=1 marks any flagged channel bad)

All detection parameters (including the previously-hardcoded significance level) are configurable via _bad_channel_* options; documented in config-sample.py. Detectors fail gracefully and skip when channels are too few. Adds tests covering each detector, the intermittent-vs-full-recording gap, consensus voting, and the candidates sidecar round-trip.