### PR TITLE
Add volume-source-space option to the LCMV beamformer

### DIFF
--- a/docs/config-sample.py
+++ b/docs/config-sample.py
@@ -550,6 +550,29 @@ inverse_method = "dSPM"
 
 _run_beamformer = True  # master switch
 
+# Source space for the beamformer forward model.
+#   'surface' : cortical-surface source space built by mne-bids-pipeline
+#               (uses SECTION 17 `spacing`/`mindist`; per-hemisphere STCs saved
+#               as `*+lcmv+hemi-stc.h5`).  DEFAULT — backward-compatible.
+#   'volume'  : regular 3D grid inside the inner skull, built on the fly by
+#               run_beamformer.py via mne.setup_volume_source_space; the volume
+#               forward is cached as `*_acq-vol_fwd.fif` and STCs are saved as
+#               `*+lcmv+vol-vl.h5` (rendered with nilearn, not the surface Brain).
+_beamformer_source_space = "surface"
+
+# --- Volume-source-space options (only used when source_space == 'volume') ---
+# Grid spacing (mm) of the volume source space.  Smaller = finer and slower.
+_beamformer_volume_pos = 5.0
+# Minimum distance (mm) of grid points from the inner skull (defaults to `mindist`).
+_beamformer_volume_mindist = mindist
+# BEM used to build the volume forward when none is cached on disk.  For MEG-only
+# OPM data a single-shell conductivity `(0.3,)` is appropriate; `ico` sets the
+# surface tessellation when the BEM model has to be built from FreeSurfer surfaces.
+_beamformer_volume_bem_conductivity = (0.3,)
+_beamformer_volume_bem_ico = 4
+# Cache the built volume forward to `*_acq-vol_fwd.fif` for reuse across reruns.
+_beamformer_volume_cache = True
+
 # Regularisation added to the data covariance before inversion (0.01–0.10).
 _beamformer_reg = 0.05
 
@@ -783,6 +806,15 @@ if _beamformer_pick_ori == "vector":
 assert _beamformer_power_tmin < _beamformer_power_tmax, (
     f"_beamformer_power_tmin ({_beamformer_power_tmin}) must be < "
     f"_beamformer_power_tmax ({_beamformer_power_tmax})."
+)
+assert _beamformer_source_space in {"surface", "volume"}, (
+    f"_beamformer_source_space must be 'surface' or 'volume'; got '{_beamformer_source_space}'."
+)
+assert _beamformer_volume_pos > 0, (
+    f"_beamformer_volume_pos must be > 0 (mm), got {_beamformer_volume_pos}."
+)
+assert _beamformer_volume_mindist >= 0, (
+    f"_beamformer_volume_mindist must be >= 0 (mm), got {_beamformer_volume_mindist}."
 )
 
 # -- Source estimation --

--- a/src/custom/run_beamformer.py
+++ b/src/custom/run_beamformer.py
@@ -27,13 +27,14 @@ from typing import Any, Dict
 import mne
 import numpy as np
 from mne.beamformer import apply_lcmv, apply_lcmv_cov, make_lcmv
-from mne_bids import BIDSPath
+from mne_bids import BIDSPath, get_head_mri_trans
 
 # Add mne-bids-pipeline to path for importing utilities
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "mne-bids-pipeline"))
 
 from mne_bids_pipeline._config_import import _update_config_from_path, _import_config
 from mne_bids_pipeline._config_utils import (
+    _get_bem_conductivity,
     get_fs_subject,
     get_fs_subjects_dir,
     get_noise_cov_bids_path,
@@ -81,6 +82,180 @@ def load_config(config_path: str) -> SimpleNamespace:
 
 
 # --------------------------------------------------------------------------------------
+# Volume Forward Solution
+# --------------------------------------------------------------------------------------
+
+
+def _find_bem_solution(fs_subjects_dir: str, fs_subject: str, tag: str) -> Path | None:
+    """Locate an existing BEM solution in the FreeSurfer subject ``bem/`` directory.
+
+    Prefers the conductivity-tagged file the pipeline writes
+    (``{fs_subject}-{tag}-bem-sol.fif``), then falls back to any ``*bem-sol.fif``.
+    Mirrors ``coreg_diagnostics._find_bem_solution`` but honours the pipeline's
+    ``_get_bem_conductivity`` tag so the OPM single-layer solution is found first.
+    """
+    bem_dir = Path(fs_subjects_dir) / fs_subject / "bem"
+    if not bem_dir.exists():
+        return None
+    tagged = bem_dir / f"{fs_subject}-{tag}-bem-sol.fif"
+    if tagged.exists():
+        return tagged
+    matches = sorted(bem_dir.glob("*bem-sol.fif"))
+    if not matches:
+        return None
+    for m in matches:
+        if m.name.startswith(fs_subject):
+            return m
+    return matches[0]
+
+
+def build_volume_forward(cfg: SimpleNamespace, info: mne.Info) -> mne.Forward:
+    """Build (or load a cached) volume-source-space forward solution.
+
+    mne-bids-pipeline only ever builds *surface* forward solutions, so a volume
+    beamformer needs its own forward.  This adapts the on-the-fly forward pattern
+    from ``coreg_diagnostics._compute_forward``, swapping ``setup_source_space``
+    for :func:`mne.setup_volume_source_space` (a regular 3D grid bounded by the
+    BEM inner-skull surface).
+
+    The result is cached to ``*_acq-vol_fwd.fif`` (the forward file embeds its
+    volume ``src``) and reused on subsequent runs when
+    ``_beamformer_volume_cache`` is set.
+
+    Parameters
+    ----------
+    cfg : SimpleNamespace
+        Configuration object.  Reads ``_beamformer_volume_pos`` (grid spacing,
+        mm), ``_beamformer_volume_mindist`` (mm from inner skull),
+        ``_beamformer_volume_bem_conductivity``, ``_beamformer_volume_bem_ico``
+        and ``_beamformer_volume_cache``.
+    info : mne.Info
+        Measurement info (sensor geometry) the forward is computed for.
+
+    Returns
+    -------
+    fwd : mne.Forward
+        Volume-source-space forward solution.
+    """
+    print("\n[build_volume_forward] Building volume-source-space forward...")
+
+    subject = cfg.subjects[0]
+    session = cfg.sessions[0]
+
+    fs_subject = get_fs_subject(config=cfg, subject=subject, session=session)
+    fs_subjects_dir = get_fs_subjects_dir(config=cfg)
+    print(
+        f"[build_volume_forward] FreeSurfer subject={fs_subject}, "
+        f"subjects_dir={fs_subjects_dir}"
+    )
+
+    bids_path = BIDSPath(
+        subject=subject,
+        session=session,
+        task=cfg.task,
+        root=cfg.deriv_root,
+        datatype=cfg.datatype,
+        check=False,
+    )
+
+    pos = float(getattr(cfg, "_beamformer_volume_pos", 5.0))
+    mindist = float(getattr(cfg, "_beamformer_volume_mindist", getattr(cfg, "mindist", 5.0)))
+    cache = getattr(cfg, "_beamformer_volume_cache", True)
+
+    # Cache -----------------------------------------------------------------
+    vol_fwd_path = bids_path.copy().update(
+        suffix="fwd", acquisition="vol", extension=".fif"
+    )
+    if cache and vol_fwd_path.fpath.exists():
+        print(f"[build_volume_forward] Loading cached volume forward: {vol_fwd_path.fpath}")
+        return mne.read_forward_solution(vol_fwd_path.fpath)
+
+    # BEM solution ----------------------------------------------------------
+    conductivity_default, tag = _get_bem_conductivity(cfg)
+    bem_path = _find_bem_solution(fs_subjects_dir, fs_subject, tag)
+    if bem_path is not None:
+        print(f"[build_volume_forward] Loading BEM solution: {bem_path}")
+        bem = mne.read_bem_solution(bem_path)
+    else:
+        conductivity = tuple(
+            getattr(cfg, "_beamformer_volume_bem_conductivity", (0.3,))
+        )
+        ico = int(getattr(cfg, "_beamformer_volume_bem_ico", 4))
+        print(
+            f"[build_volume_forward] No BEM on disk; building model "
+            f"(conductivity={conductivity}, ico={ico})"
+        )
+        model = mne.make_bem_model(
+            subject=fs_subject,
+            ico=ico,
+            conductivity=conductivity,
+            subjects_dir=fs_subjects_dir,
+        )
+        bem = mne.make_bem_solution(model)
+
+    # Head <-> MRI transform ------------------------------------------------
+    # Prefer the trans the pipeline already wrote next to the surface forward;
+    # fall back to recomputing it from the BIDS anatomical landmarks.
+    trans = None
+    trans_path = bids_path.copy().update(suffix="trans", extension=".fif")
+    if trans_path.fpath.exists():
+        print(f"[build_volume_forward] Loading head-MRI trans: {trans_path.fpath}")
+        trans = mne.read_trans(trans_path.fpath)
+    else:
+        print("[build_volume_forward] No trans on disk; deriving from BIDS landmarks")
+        t1_bids_path = BIDSPath(
+            subject=subject,
+            session=session,
+            root=cfg.bids_root,
+            datatype="anat",
+            suffix="T1w",
+            extension=".nii.gz",
+            check=False,
+        )
+        trans = get_head_mri_trans(
+            bids_path,
+            fs_subject=fs_subject,
+            fs_subjects_dir=fs_subjects_dir,
+            t1_bids_path=t1_bids_path,
+        )
+
+    # Volume source space (grid bounded by the BEM inner skull) -------------
+    print(f"[build_volume_forward] Setting up volume source space (pos={pos} mm)")
+    src = mne.setup_volume_source_space(
+        subject=fs_subject,
+        pos=pos,
+        bem=bem,
+        subjects_dir=fs_subjects_dir,
+        add_interpolator=True,
+    )
+    print(f"[build_volume_forward] Volume source space: {sum(s['nuse'] for s in src)} sources")
+
+    # Forward solution ------------------------------------------------------
+    print("[build_volume_forward] Computing forward solution...")
+    fwd = mne.make_forward_solution(
+        info,
+        trans=trans,
+        src=src,
+        bem=bem,
+        meg=True,
+        eeg=False,
+        mindist=mindist,
+        n_jobs=getattr(cfg, "n_jobs", 1),
+    )
+
+    # Persist for reuse -----------------------------------------------------
+    if cache:
+        try:
+            vol_fwd_path.fpath.parent.mkdir(parents=True, exist_ok=True)
+            mne.write_forward_solution(vol_fwd_path.fpath, fwd, overwrite=True)
+            print(f"[build_volume_forward] Cached volume forward to {vol_fwd_path.fpath}")
+        except Exception as e:
+            print(f"[build_volume_forward] WARNING: could not cache forward: {e}")
+
+    return fwd
+
+
+# --------------------------------------------------------------------------------------
 # Data Loading
 # --------------------------------------------------------------------------------------
 
@@ -118,16 +293,27 @@ def load_beamformer_data(cfg: SimpleNamespace) -> Dict[str, Any]:
         check=False,
     )
 
-    # Load forward solution
-    fwd_path = bids_path.copy().update(suffix="fwd", extension=".fif")
-    if not fwd_path.fpath.exists():
-        raise FileNotFoundError(
-            f"Forward solution not found at {fwd_path.fpath}\n"
-            f"Run forward modeling first with:\n"
-            f"  mne_bids_pipeline --steps=source/make_forward --config=<config>"
+    # Source-space type: 'surface' (mne-bids-pipeline forward) or 'volume'
+    # (built on the fly from the measurement info; see build_volume_forward).
+    source_space = getattr(cfg, "_beamformer_source_space", "surface")
+    if source_space not in ("surface", "volume"):
+        raise ValueError(
+            f"Invalid _beamformer_source_space: {source_space!r}. "
+            f"Must be 'surface' or 'volume'."
         )
-    print(f"[load_beamformer_data] Loading forward solution: {fwd_path.fpath}")
-    data["forward"] = mne.read_forward_solution(fwd_path)
+    print(f"[load_beamformer_data] Source space: {source_space}")
+
+    # Load surface forward solution (volume forward is built after epochs/info).
+    if source_space == "surface":
+        fwd_path = bids_path.copy().update(suffix="fwd", extension=".fif")
+        if not fwd_path.fpath.exists():
+            raise FileNotFoundError(
+                f"Forward solution not found at {fwd_path.fpath}\n"
+                f"Run forward modeling first with:\n"
+                f"  mne_bids_pipeline --steps=source/make_forward --config=<config>"
+            )
+        print(f"[load_beamformer_data] Loading forward solution: {fwd_path.fpath}")
+        data["forward"] = mne.read_forward_solution(fwd_path)
 
     # Load clean epochs
     epochs_path = bids_path.copy().update(
@@ -140,6 +326,10 @@ def load_beamformer_data(cfg: SimpleNamespace) -> Dict[str, Any]:
     print(f"[load_beamformer_data] Loading epochs: {epochs_path.fpath}")
     data["epochs"] = mne.read_epochs(epochs_path, preload=True)
     data["info"] = mne.io.read_info(epochs_path)
+
+    # Build (or load cached) volume forward from the measurement info.
+    if source_space == "volume":
+        data["forward"] = build_volume_forward(cfg, data["info"])
 
     # Load noise covariance
     if cfg.noise_cov == "ad-hoc":
@@ -547,14 +737,22 @@ def save_beamformer_results(
         filters.save(filter_path.fpath, overwrite=True)
         out_files["filters"] = filter_path.fpath
 
+    # Volume STCs are stored under a distinct "+vol" token (and save as "-vl.h5")
+    # so downstream tooling can tell them apart from surface "+hemi" ("-stc.h5").
+    space_tag = (
+        "vol"
+        if getattr(cfg, "_beamformer_source_space", "surface") == "volume"
+        else "hemi"
+    )
+
     # Save source estimates
     for condition, stc in stcs.items():
         # Create suffix based on analysis type
         cond_sanitized = sanitize_cond_name(condition)
         if analysis_type == "time":
-            suffix = f"{cond_sanitized}+lcmv+hemi"
+            suffix = f"{cond_sanitized}+lcmv+{space_tag}"
         else:  # power
-            suffix = f"{cond_sanitized}+lcmv-power+hemi"
+            suffix = f"{cond_sanitized}+lcmv-power+{space_tag}"
 
         stc_path = bids_path.copy().update(suffix=suffix)
         print(f"  - Saving {condition} to: {stc_path.fpath}")
@@ -576,6 +774,7 @@ def add_to_report(
     cfg: SimpleNamespace,
     stcs: Dict[str, Path],
     analysis_type: str,
+    src: "mne.SourceSpaces | None" = None,
 ) -> None:
     """Add beamformer results to MNE-BIDS-Pipeline HTML report.
 
@@ -587,10 +786,17 @@ def add_to_report(
         Dictionary mapping condition names to STC file paths.
     analysis_type : str
         'time' or 'power' to distinguish analysis types.
+    src : mne.SourceSpaces or None
+        Volume source space.  Required when ``_beamformer_source_space ==
+        'volume'``: ``report.add_stc`` cannot render volume estimates (it has no
+        ``src`` parameter), so each volume STC is plotted with
+        ``stc.plot(src=..., mode='stat_map')`` and added as a figure instead.
     """
     if not cfg._beamformer_add_to_report:
         print(f"\n[add_to_report] Report generation disabled. Skipping.")
         return
+
+    is_volume = getattr(cfg, "_beamformer_source_space", "surface") == "volume"
 
     print(f"\n[add_to_report] Adding {analysis_type} beamformer results to report...")
 
@@ -636,16 +842,48 @@ def add_to_report(
                 if condition not in cfg.conditions:
                     tags = tags + ("contrast",)
 
-                # Add to report
-                report.add_stc(
-                    stc=stc_path,
-                    title=f"Beamformer ({analysis_type}): {condition}",
-                    subject=fs_subject,
-                    subjects_dir=fs_subjects_dir,
-                    n_time_points=cfg.report_stc_n_time_points,
-                    tags=tags,
-                    replace=True,
-                )
+                if is_volume:
+                    # report.add_stc has no `src` argument and cannot render a
+                    # VolSourceEstimate, so plot it with nilearn and add the
+                    # resulting figure instead.
+                    if src is None:
+                        print(
+                            f"    [WARNING] Volume STC but no source space provided; "
+                            f"skipping report figure for {condition}"
+                        )
+                        continue
+                    import matplotlib.pyplot as plt
+
+                    stc = mne.read_source_estimate(str(stc_path))
+                    # Representative slice at the peak of the mean-over-sources signal.
+                    peak_time = stc.times[
+                        int(np.argmax(np.abs(stc.data).mean(axis=0)))
+                    ]
+                    fig = stc.plot(
+                        src=src,
+                        subject=fs_subject,
+                        subjects_dir=fs_subjects_dir,
+                        mode="stat_map",
+                        initial_time=peak_time,
+                        show=False,
+                    )
+                    report.add_figure(
+                        fig=fig,
+                        title=f"Beamformer ({analysis_type}): {condition}",
+                        tags=tags,
+                        replace=True,
+                    )
+                    plt.close(fig)
+                else:
+                    report.add_stc(
+                        stc=stc_path,
+                        title=f"Beamformer ({analysis_type}): {condition}",
+                        subject=fs_subject,
+                        subjects_dir=fs_subjects_dir,
+                        n_time_points=cfg.report_stc_n_time_points,
+                        tags=tags,
+                        replace=True,
+                    )
                 print(f"    - tags: {tags}")
 
             print(
@@ -762,6 +1000,7 @@ def main():
             cfg=cfg,
             stcs=out_files_time,
             analysis_type="time",
+            src=data["forward"]["src"],
         )
 
     # Run Power beamformer --------------------------------
@@ -787,6 +1026,7 @@ def main():
             cfg=cfg,
             stcs=out_files_power,
             analysis_type="power",
+            src=data["forward"]["src"],
         )
 
     print("\n" + "=" * 80)

--- a/tests/test_beamformer_volume.py
+++ b/tests/test_beamformer_volume.py
@@ -1,0 +1,438 @@
+"""Tests for the volume-source-space beamformer path in run_beamformer.py.
+
+Covers ``build_volume_forward`` (cache hit/miss, BEM found vs built), the
+volume branch of ``load_beamformer_data``, the ``+vol`` naming in
+``save_beamformer_results``, and the nilearn figure path in ``add_to_report``.
+
+Follows the repo's mock-only convention: no real forward solutions, source
+spaces, or BEM surfaces are ever built — the MNE constructors are patched at
+``custom.run_beamformer.*``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mne
+import numpy as np
+import pytest
+
+from custom.run_beamformer import (
+    _find_bem_solution,
+    add_to_report,
+    build_volume_forward,
+    load_beamformer_data,
+    save_beamformer_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def vol_cfg(tmp_path):
+    """Beamformer config with volume-source-space options."""
+    deriv = tmp_path / "derivatives"
+    deriv.mkdir()
+    return SimpleNamespace(
+        subjects=["001"],
+        sessions=["01"],
+        task="restingstate",
+        bids_root=str(tmp_path / "bids"),
+        deriv_root=str(deriv),
+        datatype="meg",
+        n_jobs=1,
+        noise_cov="ad-hoc",
+        conditions=["stim_a", "stim_b"],
+        contrasts=[],
+        ch_types=["mag"],
+        mindist=5,
+        _run_beamformer=True,
+        _beamformer_reg=0.05,
+        _beamformer_pick_ori="max-power",
+        _beamformer_weight_norm="unit-noise-gain",
+        _beamformer_depth=None,
+        _beamformer_rank=None,
+        _beamformer_save_filters=False,
+        _beamformer_add_to_report=False,
+        _beamformer_power_tmin=0.0,
+        _beamformer_power_tmax=0.5,
+        # volume options
+        _beamformer_source_space="volume",
+        _beamformer_volume_pos=5.0,
+        _beamformer_volume_mindist=5.0,
+        _beamformer_volume_bem_conductivity=(0.3,),
+        _beamformer_volume_bem_ico=4,
+        _beamformer_volume_cache=True,
+    )
+
+
+def _patch_common(stack_extra=None):
+    """Common patches: fs helpers + BEM conductivity tag."""
+    return dict(
+        get_fs_subject=patch(
+            "custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"
+        ),
+        get_fs_subjects_dir=patch(
+            "custom.run_beamformer.get_fs_subjects_dir",
+            return_value="/fake/subjects_dir",
+        ),
+        bem_tag=patch(
+            "custom.run_beamformer._get_bem_conductivity",
+            return_value=((0.3,), "5120"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _find_bem_solution
+# ---------------------------------------------------------------------------
+
+
+class TestFindBemSolution:
+    def test_missing_dir_returns_none(self, tmp_path):
+        assert _find_bem_solution(str(tmp_path), "sub-001_ses-01", "5120") is None
+
+    def test_prefers_tagged_file(self, tmp_path):
+        fs_subject = "sub-001_ses-01"
+        bem_dir = tmp_path / fs_subject / "bem"
+        bem_dir.mkdir(parents=True)
+        tagged = bem_dir / f"{fs_subject}-5120-bem-sol.fif"
+        tagged.touch()
+        (bem_dir / f"{fs_subject}-other-bem-sol.fif").touch()
+        found = _find_bem_solution(str(tmp_path), fs_subject, "5120")
+        assert found == tagged
+
+    def test_falls_back_to_glob(self, tmp_path):
+        fs_subject = "sub-001_ses-01"
+        bem_dir = tmp_path / fs_subject / "bem"
+        bem_dir.mkdir(parents=True)
+        other = bem_dir / f"{fs_subject}-1234-bem-sol.fif"
+        other.touch()
+        found = _find_bem_solution(str(tmp_path), fs_subject, "5120")
+        assert found == other
+
+
+# ---------------------------------------------------------------------------
+# build_volume_forward
+# ---------------------------------------------------------------------------
+
+
+class TestBuildVolumeForward:
+    def test_cache_hit_returns_without_building(self, vol_cfg):
+        """When a cached volume forward exists, it is read and returned as-is."""
+        # Create the cached file at the path build_volume_forward computes.
+        from mne_bids import BIDSPath
+
+        vol_fwd = BIDSPath(
+            subject="001",
+            session="01",
+            task="restingstate",
+            root=vol_cfg.deriv_root,
+            datatype="meg",
+            acquisition="vol",
+            suffix="fwd",
+            extension=".fif",
+            check=False,
+        )
+        vol_fwd.fpath.parent.mkdir(parents=True, exist_ok=True)
+        vol_fwd.fpath.touch()
+
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        sentinel = MagicMock(spec=mne.Forward)
+
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer.mne.read_forward_solution",
+                return_value=sentinel,
+            ) as mock_read,
+            patch("custom.run_beamformer.mne.setup_volume_source_space") as mock_vol,
+            patch("custom.run_beamformer.mne.make_forward_solution") as mock_fwd,
+        ):
+            result = build_volume_forward(vol_cfg, info)
+
+        assert result is sentinel
+        mock_read.assert_called_once()
+        mock_vol.assert_not_called()
+        mock_fwd.assert_not_called()
+
+    def test_cache_miss_builds_and_writes(self, vol_cfg):
+        """Cache miss + BEM on disk -> build volume src + forward, then cache it."""
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        fake_bem = MagicMock(name="bem")
+        fake_src = MagicMock(name="src")
+        fake_fwd = MagicMock(spec=mne.Forward)
+
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._get_bem_conductivity",
+                return_value=((0.3,), "5120"),
+            ),
+            patch(
+                "custom.run_beamformer._find_bem_solution",
+                return_value=Path("/fake/bem-sol.fif"),
+            ),
+            patch(
+                "custom.run_beamformer.mne.read_bem_solution", return_value=fake_bem
+            ) as mock_read_bem,
+            patch("custom.run_beamformer.mne.make_bem_model") as mock_make_model,
+            patch(
+                "custom.run_beamformer.get_head_mri_trans", return_value="TRANS"
+            ) as mock_trans,
+            patch(
+                "custom.run_beamformer.mne.setup_volume_source_space",
+                return_value=fake_src,
+            ) as mock_vol,
+            patch(
+                "custom.run_beamformer.mne.make_forward_solution", return_value=fake_fwd
+            ) as mock_fwd,
+            patch("custom.run_beamformer.mne.write_forward_solution") as mock_write,
+        ):
+            result = build_volume_forward(vol_cfg, info)
+
+        assert result is fake_fwd
+        mock_read_bem.assert_called_once()  # BEM loaded from disk
+        mock_make_model.assert_not_called()  # not rebuilt
+        # volume source space built with the configured grid spacing
+        assert mock_vol.call_args.kwargs["pos"] == 5.0
+        assert mock_vol.call_args.kwargs["bem"] is fake_bem
+        # forward built on the volume src and cached
+        assert mock_fwd.call_args.kwargs["src"] is fake_src
+        mock_write.assert_called_once()
+
+    def test_cache_miss_builds_bem_when_absent(self, vol_cfg):
+        """When no BEM is on disk, one is built via make_bem_model/solution."""
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._get_bem_conductivity",
+                return_value=((0.3,), "5120"),
+            ),
+            patch("custom.run_beamformer._find_bem_solution", return_value=None),
+            patch(
+                "custom.run_beamformer.mne.make_bem_model", return_value="MODEL"
+            ) as mock_model,
+            patch(
+                "custom.run_beamformer.mne.make_bem_solution", return_value="BEM"
+            ) as mock_sol,
+            patch("custom.run_beamformer.get_head_mri_trans", return_value="TRANS"),
+            patch(
+                "custom.run_beamformer.mne.setup_volume_source_space",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom.run_beamformer.mne.make_forward_solution",
+                return_value=MagicMock(spec=mne.Forward),
+            ),
+            patch("custom.run_beamformer.mne.write_forward_solution"),
+        ):
+            build_volume_forward(vol_cfg, info)
+
+        mock_model.assert_called_once()
+        assert mock_model.call_args.kwargs["ico"] == 4
+        assert mock_model.call_args.kwargs["conductivity"] == (0.3,)
+        mock_sol.assert_called_once_with("MODEL")
+
+    def test_no_cache_does_not_write(self, vol_cfg):
+        """With caching disabled, the forward is built but never written."""
+        vol_cfg._beamformer_volume_cache = False
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._get_bem_conductivity",
+                return_value=((0.3,), "5120"),
+            ),
+            patch(
+                "custom.run_beamformer._find_bem_solution",
+                return_value=Path("/fake/bem-sol.fif"),
+            ),
+            patch("custom.run_beamformer.mne.read_bem_solution", return_value="BEM"),
+            patch("custom.run_beamformer.get_head_mri_trans", return_value="TRANS"),
+            patch(
+                "custom.run_beamformer.mne.setup_volume_source_space",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom.run_beamformer.mne.make_forward_solution",
+                return_value=MagicMock(spec=mne.Forward),
+            ),
+            patch("custom.run_beamformer.mne.write_forward_solution") as mock_write,
+        ):
+            build_volume_forward(vol_cfg, info)
+        mock_write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# load_beamformer_data — volume branch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBeamformerDataVolume:
+    def test_volume_mode_builds_forward(self, vol_cfg):
+        """Volume mode loads epochs/info then delegates to build_volume_forward,
+        without requiring a surface fwd file."""
+        deriv = Path(vol_cfg.deriv_root)
+        meg_dir = deriv / "sub-001" / "ses-01" / "meg"
+        meg_dir.mkdir(parents=True)
+        epo_path = meg_dir / "sub-001_ses-01_task-restingstate_proc-clean_epo.fif"
+        epo_path.touch()
+
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        fake_fwd = MagicMock(spec=mne.Forward)
+        fake_fwd.__getitem__ = lambda self, key: [1] if key == "src" else None
+
+        mock_epochs = MagicMock(spec=mne.Epochs)
+        mock_epochs.__len__ = lambda self: 10
+        mock_epochs.ch_names = ["MEG001"]
+
+        with (
+            patch("custom.run_beamformer.mne.read_epochs", return_value=mock_epochs),
+            patch("custom.run_beamformer.mne.io.read_info", return_value=info),
+            patch(
+                "custom.run_beamformer.build_volume_forward", return_value=fake_fwd
+            ) as mock_build,
+        ):
+            data = load_beamformer_data(vol_cfg)
+
+        mock_build.assert_called_once()
+        # called with (cfg, info)
+        assert mock_build.call_args.args[0] is vol_cfg
+        assert data["forward"] is fake_fwd
+        assert data["noise_path"] is None  # ad-hoc
+
+    def test_invalid_source_space_raises(self, vol_cfg):
+        vol_cfg._beamformer_source_space = "banana"
+        with pytest.raises(ValueError, match="_beamformer_source_space"):
+            load_beamformer_data(vol_cfg)
+
+
+# ---------------------------------------------------------------------------
+# save_beamformer_results — volume naming
+# ---------------------------------------------------------------------------
+
+
+class TestSaveBeamformerVolumeNaming:
+    def test_volume_time_suffix(self, vol_cfg):
+        stc = MagicMock()
+        stcs = {"stim_a": stc}
+        out = save_beamformer_results(
+            vol_cfg, filters=MagicMock(), stcs=stcs, analysis_type="time"
+        )
+        saved_path = str(stc.save.call_args.args[0])
+        assert "+lcmv+vol" in saved_path
+        assert "+hemi" not in saved_path
+        assert "stim_a" in out
+
+    def test_volume_power_suffix(self, vol_cfg):
+        stc = MagicMock()
+        save_beamformer_results(
+            vol_cfg, filters=MagicMock(), stcs={"stim_a": stc}, analysis_type="power"
+        )
+        saved_path = str(stc.save.call_args.args[0])
+        assert "+lcmv-power+vol" in saved_path
+
+    def test_surface_still_uses_hemi(self, vol_cfg):
+        """Sanity check: surface mode keeps the +hemi token."""
+        vol_cfg._beamformer_source_space = "surface"
+        stc = MagicMock()
+        save_beamformer_results(
+            vol_cfg, filters=MagicMock(), stcs={"stim_a": stc}, analysis_type="time"
+        )
+        assert "+lcmv+hemi" in str(stc.save.call_args.args[0])
+
+
+# ---------------------------------------------------------------------------
+# add_to_report — volume figure path
+# ---------------------------------------------------------------------------
+
+
+class TestAddToReportVolume:
+    def _report_cm(self, mock_report):
+        cm = MagicMock()
+        cm.__enter__ = lambda self: mock_report
+        cm.__exit__ = lambda self, *a: False
+        return cm
+
+    def test_volume_uses_add_figure_not_add_stc(self, vol_cfg):
+        vol_cfg._beamformer_add_to_report = True
+        vol_cfg.exec_params = MagicMock()
+        vol_cfg.report_stc_n_time_points = 51
+
+        mock_report = MagicMock()
+        mock_stc = MagicMock()
+        mock_stc.data = np.random.randn(4, 10)
+        mock_stc.times = np.linspace(0, 1, 10)
+
+        stcs = {"stim_a": Path("/fake/sub-001_stim_a+lcmv+vol")}
+
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._open_report",
+                return_value=self._report_cm(mock_report),
+            ),
+            patch(
+                "custom.run_beamformer.mne.read_source_estimate",
+                return_value=mock_stc,
+            ),
+            patch("custom.run_beamformer._sanitize_cond_tag", side_effect=lambda c: c),
+        ):
+            add_to_report(vol_cfg, stcs, analysis_type="time", src=MagicMock())
+
+        mock_report.add_figure.assert_called_once()
+        mock_report.add_stc.assert_not_called()
+        mock_stc.plot.assert_called_once()
+        # src threaded through to the volume plot
+        assert "src" in mock_stc.plot.call_args.kwargs
+
+    def test_volume_without_src_skips(self, vol_cfg, capsys):
+        vol_cfg._beamformer_add_to_report = True
+        vol_cfg.exec_params = MagicMock()
+        vol_cfg.report_stc_n_time_points = 51
+        mock_report = MagicMock()
+        stcs = {"stim_a": Path("/fake/sub-001_stim_a+lcmv+vol")}
+
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._open_report",
+                return_value=self._report_cm(mock_report),
+            ),
+            patch("custom.run_beamformer._sanitize_cond_tag", side_effect=lambda c: c),
+        ):
+            add_to_report(vol_cfg, stcs, analysis_type="time", src=None)
+
+        mock_report.add_figure.assert_not_called()
+        assert "no source space" in capsys.readouterr().out


### PR DESCRIPTION
Fit the LCMV beamformer in a volume source space in addition to the existing cortical surface, governed by a new `_beamformer_source_space` config option ('surface' default | 'volume').

mne-bids-pipeline only ever builds surface forwards, so the volume source space + forward are built on the fly in run_beamformer.py (`build_volume_forward`: setup_volume_source_space + make_forward_solution, reusing the coreg_diagnostics BEM/trans pattern) and cached as `*_acq-vol_fwd.fif`. Volume STCs are saved under a distinct `+vol` token (`-vl.h5`) and added to the HTML report as nilearn stat_map figures, since `report.add_stc` cannot render volume estimates.

Document the new options (with validation) in docs/config-sample.py and add tests/test_beamformer_volume.py covering the forward build (cache hit/miss, BEM build), the load_beamformer_data volume branch, the `+vol` naming, and the report figure path.