### PR TITLE
Allow _beamformer_source_space to be a list (run surface + volume)

### DIFF
--- a/docs/config-sample.py
+++ b/docs/config-sample.py
@@ -558,6 +558,10 @@ _run_beamformer = True  # master switch
 #               run_beamformer.py via mne.setup_volume_source_space; the volume
 #               forward is cached as `*_acq-vol_fwd.fif` and STCs are saved as
 #               `*+lcmv+vol-vl.h5` (rendered with nilearn, not the surface Brain).
+# May also be a LIST to run both reconstructions in one invocation, e.g.
+#   _beamformer_source_space = ["surface", "volume"]
+# Each space gets its own forward, filters (volume filters tagged `_acq-vol`),
+# STCs, and report entries, so the two never collide.
 _beamformer_source_space = "surface"
 
 # --- Volume-source-space options (only used when source_space == 'volume') ---
@@ -807,8 +811,16 @@ assert _beamformer_power_tmin < _beamformer_power_tmax, (
     f"_beamformer_power_tmin ({_beamformer_power_tmin}) must be < "
     f"_beamformer_power_tmax ({_beamformer_power_tmax})."
 )
-assert _beamformer_source_space in {"surface", "volume"}, (
-    f"_beamformer_source_space must be 'surface' or 'volume'; got '{_beamformer_source_space}'."
+_bf_source_spaces = (
+    [_beamformer_source_space]
+    if isinstance(_beamformer_source_space, str)
+    else list(_beamformer_source_space)
+)
+assert _bf_source_spaces and all(
+    _s in {"surface", "volume"} for _s in _bf_source_spaces
+), (
+    f"_beamformer_source_space must be 'surface', 'volume', or a list of those; "
+    f"got {_beamformer_source_space!r}."
 )
 assert _beamformer_volume_pos > 0, (
     f"_beamformer_volume_pos must be > 0 (mm), got {_beamformer_volume_pos}."

--- a/src/custom/run_beamformer.py
+++ b/src/custom/run_beamformer.py
@@ -81,6 +81,30 @@ def load_config(config_path: str) -> SimpleNamespace:
     return cfg
 
 
+def resolve_source_spaces(cfg: SimpleNamespace) -> list[str]:
+    """Return the beamformer source spaces to run, as an ordered unique list.
+
+    ``_beamformer_source_space`` may be a single string (``"surface"`` |
+    ``"volume"``) or a list/tuple of them (e.g. ``["volume", "surface"]``) to run
+    both reconstructions in one invocation.  Duplicates are collapsed and the
+    given order is preserved.
+    """
+    val = getattr(cfg, "_beamformer_source_space", "surface")
+    spaces = [val] if isinstance(val, str) else list(val)
+    resolved: list[str] = []
+    for s in spaces:
+        if s not in ("surface", "volume"):
+            raise ValueError(
+                f"Invalid _beamformer_source_space entry: {s!r}. "
+                f"Must be 'surface' or 'volume'."
+            )
+        if s not in resolved:
+            resolved.append(s)
+    if not resolved:
+        raise ValueError("_beamformer_source_space must not be empty.")
+    return resolved
+
+
 # --------------------------------------------------------------------------------------
 # Volume Forward Solution
 # --------------------------------------------------------------------------------------
@@ -293,18 +317,15 @@ def load_beamformer_data(cfg: SimpleNamespace) -> Dict[str, Any]:
         check=False,
     )
 
-    # Source-space type: 'surface' (mne-bids-pipeline forward) or 'volume'
-    # (built on the fly from the measurement info; see build_volume_forward).
-    source_space = getattr(cfg, "_beamformer_source_space", "surface")
-    if source_space not in ("surface", "volume"):
-        raise ValueError(
-            f"Invalid _beamformer_source_space: {source_space!r}. "
-            f"Must be 'surface' or 'volume'."
-        )
-    print(f"[load_beamformer_data] Source space: {source_space}")
+    # Source space(s) to reconstruct: 'surface' (mne-bids-pipeline forward),
+    # 'volume' (built on the fly from the measurement info), or a list of both.
+    source_spaces = resolve_source_spaces(cfg)
+    print(f"[load_beamformer_data] Source space(s): {source_spaces}")
+    data["forwards"] = {}
 
-    # Load surface forward solution (volume forward is built after epochs/info).
-    if source_space == "surface":
+    # Load surface forward up front so a missing one errors clearly (volume
+    # forwards are built after epochs/info, which they require).
+    if "surface" in source_spaces:
         fwd_path = bids_path.copy().update(suffix="fwd", extension=".fif")
         if not fwd_path.fpath.exists():
             raise FileNotFoundError(
@@ -313,7 +334,7 @@ def load_beamformer_data(cfg: SimpleNamespace) -> Dict[str, Any]:
                 f"  mne_bids_pipeline --steps=source/make_forward --config=<config>"
             )
         print(f"[load_beamformer_data] Loading forward solution: {fwd_path.fpath}")
-        data["forward"] = mne.read_forward_solution(fwd_path)
+        data["forwards"]["surface"] = mne.read_forward_solution(fwd_path)
 
     # Load clean epochs
     epochs_path = bids_path.copy().update(
@@ -328,8 +349,11 @@ def load_beamformer_data(cfg: SimpleNamespace) -> Dict[str, Any]:
     data["info"] = mne.io.read_info(epochs_path)
 
     # Build (or load cached) volume forward from the measurement info.
-    if source_space == "volume":
-        data["forward"] = build_volume_forward(cfg, data["info"])
+    if "volume" in source_spaces:
+        data["forwards"]["volume"] = build_volume_forward(cfg, data["info"])
+
+    # Back-compat: expose the first requested space's forward as data["forward"].
+    data["forward"] = data["forwards"][source_spaces[0]]
 
     # Load noise covariance
     if cfg.noise_cov == "ad-hoc":
@@ -695,6 +719,7 @@ def save_beamformer_results(
     filters: dict,
     stcs: Dict[str, mne.SourceEstimate],
     analysis_type: str,
+    source_space: str | None = None,
 ) -> Dict[str, Path]:
     """Save beamformer results to BIDS derivatives.
 
@@ -708,13 +733,22 @@ def save_beamformer_results(
         Source estimates for each condition.
     analysis_type : str
         'time' or 'power' to distinguish analysis types.
+    source_space : str or None
+        'surface' or 'volume'.  Controls the STC/filter naming so both
+        reconstructions can coexist.  When ``None``, the first entry of
+        ``_beamformer_source_space`` is used (single-space back-compat).
 
     Returns
     -------
     out_files : dict
         Dictionary mapping condition names to output file paths.
     """
-    print(f"\n[save_beamformer_results] Saving {analysis_type} beamformer results...")
+    if source_space is None:
+        source_space = resolve_source_spaces(cfg)[0]
+    print(
+        f"\n[save_beamformer_results] Saving {analysis_type} beamformer results "
+        f"({source_space})..."
+    )
 
     subject = cfg.subjects[0]
     session = cfg.sessions[0]
@@ -730,20 +764,18 @@ def save_beamformer_results(
         check=False,
     )
 
-    # Save filters (only once, shared by both analyses)
+    # Save filters (once per analysis; volume filters get an acq-vol tag so a
+    # combined surface+volume run does not overwrite one with the other).
     if cfg._beamformer_save_filters and analysis_type == "time":
         filter_path = bids_path.copy().update(suffix="lcmv", extension=".h5")
-        # print(f"  - Saving filters to: {filter_path.fpath}")
+        if source_space == "volume":
+            filter_path = filter_path.update(acquisition="vol")
         filters.save(filter_path.fpath, overwrite=True)
         out_files["filters"] = filter_path.fpath
 
     # Volume STCs are stored under a distinct "+vol" token (and save as "-vl.h5")
     # so downstream tooling can tell them apart from surface "+hemi" ("-stc.h5").
-    space_tag = (
-        "vol"
-        if getattr(cfg, "_beamformer_source_space", "surface") == "volume"
-        else "hemi"
-    )
+    space_tag = "vol" if source_space == "volume" else "hemi"
 
     # Save source estimates
     for condition, stc in stcs.items():
@@ -775,6 +807,7 @@ def add_to_report(
     stcs: Dict[str, Path],
     analysis_type: str,
     src: "mne.SourceSpaces | None" = None,
+    source_space: str | None = None,
 ) -> None:
     """Add beamformer results to MNE-BIDS-Pipeline HTML report.
 
@@ -787,18 +820,27 @@ def add_to_report(
     analysis_type : str
         'time' or 'power' to distinguish analysis types.
     src : mne.SourceSpaces or None
-        Volume source space.  Required when ``_beamformer_source_space ==
-        'volume'``: ``report.add_stc`` cannot render volume estimates (it has no
-        ``src`` parameter), so each volume STC is plotted with
+        Volume source space.  Required when ``source_space == 'volume'``:
+        ``report.add_stc`` cannot render volume estimates (it has no ``src``
+        parameter), so each volume STC is plotted with
         ``stc.plot(src=..., mode='stat_map')`` and added as a figure instead.
+    source_space : str or None
+        'surface' or 'volume'.  Selects the rendering path and namespaces the
+        report titles/tags so a combined run keeps both.  When ``None``, the
+        first entry of ``_beamformer_source_space`` is used.
     """
     if not cfg._beamformer_add_to_report:
         print(f"\n[add_to_report] Report generation disabled. Skipping.")
         return
 
-    is_volume = getattr(cfg, "_beamformer_source_space", "surface") == "volume"
+    if source_space is None:
+        source_space = resolve_source_spaces(cfg)[0]
+    is_volume = source_space == "volume"
 
-    print(f"\n[add_to_report] Adding {analysis_type} beamformer results to report...")
+    print(
+        f"\n[add_to_report] Adding {analysis_type} beamformer results "
+        f"({source_space}) to report..."
+    )
 
     subject = cfg.subjects[0]
     session = cfg.sessions[0]
@@ -834,9 +876,13 @@ def add_to_report(
 
                 print(f"  - Adding {condition} to report")
 
-                # Determine tags
-                tag_prefix = f"beamformer-{analysis_type}"
+                # Determine tags (namespaced by source space so a combined
+                # surface+volume run keeps both entries in the report).
+                tag_prefix = f"beamformer-{analysis_type}-{source_space}"
                 tags = (tag_prefix, _sanitize_cond_tag(condition))
+                report_title = (
+                    f"Beamformer {source_space} ({analysis_type}): {condition}"
+                )
 
                 # Add 'contrast' tag if this is a contrast
                 if condition not in cfg.conditions:
@@ -869,7 +915,7 @@ def add_to_report(
                     )
                     report.add_figure(
                         fig=fig,
-                        title=f"Beamformer ({analysis_type}): {condition}",
+                        title=report_title,
                         tags=tags,
                         replace=True,
                     )
@@ -877,7 +923,7 @@ def add_to_report(
                 else:
                     report.add_stc(
                         stc=stc_path,
-                        title=f"Beamformer ({analysis_type}): {condition}",
+                        title=report_title,
                         subject=fs_subject,
                         subjects_dir=fs_subjects_dir,
                         n_time_points=cfg.report_stc_n_time_points,
@@ -968,66 +1014,83 @@ def main():
         rank = cfg._beamformer_rank
         print(f"[main] Using specified beamformer rank: {rank}")
 
-    # Compute LCMV filters (shared by both analyses)
-    filters = compute_lcmv_filters(
-        forward=data["forward"],
-        data_cov=data_cov,
-        noise_cov=noise_cov,
-        rank=rank,
-        info=data["info"],
-        cfg=cfg,
-    )
+    # Reconstruct each requested source space (surface, volume, or both).  The
+    # data / noise covariance and rank above are shared; the forward, filters,
+    # STCs, saved filenames and report entries are per source space.
+    source_spaces = resolve_source_spaces(cfg)
+    output_type = getattr(cfg, "_beamformer_output_type", "both")
 
-    # Run Time-locked beamformer --------------------------------
-    if getattr(cfg, "_beamformer_output_type", "both") in ["time", "both"]:
-        print("\n" + "=" * 80)
-        print("TIME-LOCKED BEAMFORMER")
-        print("=" * 80)
-        stcs_time = run_beamformer_timecourse(
-            epochs=data["epochs"],
-            filters=filters,
+    for space in source_spaces:
+        print("\n" + "#" * 80)
+        print(f"SOURCE SPACE: {space.upper()}")
+        print("#" * 80)
+
+        forward = data["forwards"][space]
+
+        # Compute LCMV filters (shared by this space's time and power analyses)
+        filters = compute_lcmv_filters(
+            forward=forward,
+            data_cov=data_cov,
+            noise_cov=noise_cov,
+            rank=rank,
+            info=data["info"],
             cfg=cfg,
         )
 
-        out_files_time = save_beamformer_results(
-            cfg=cfg,
-            filters=filters,
-            stcs=stcs_time,
-            analysis_type="time",
-        )
+        # Run Time-locked beamformer --------------------------------
+        if output_type in ["time", "both"]:
+            print("\n" + "=" * 80)
+            print(f"TIME-LOCKED BEAMFORMER ({space})")
+            print("=" * 80)
+            stcs_time = run_beamformer_timecourse(
+                epochs=data["epochs"],
+                filters=filters,
+                cfg=cfg,
+            )
 
-        add_to_report(
-            cfg=cfg,
-            stcs=out_files_time,
-            analysis_type="time",
-            src=data["forward"]["src"],
-        )
+            out_files_time = save_beamformer_results(
+                cfg=cfg,
+                filters=filters,
+                stcs=stcs_time,
+                analysis_type="time",
+                source_space=space,
+            )
 
-    # Run Power beamformer --------------------------------
-    if getattr(cfg, "_beamformer_output_type", "both") in ["power", "both"]:
-        print("\n" + "=" * 80)
-        print("POWER BEAMFORMER")
-        print("=" * 80)
+            add_to_report(
+                cfg=cfg,
+                stcs=out_files_time,
+                analysis_type="time",
+                src=forward["src"],
+                source_space=space,
+            )
 
-        stcs_power = run_beamformer_power(
-            epochs=data["epochs"],
-            filters=filters,
-            cfg=cfg,
-        )
+        # Run Power beamformer --------------------------------
+        if output_type in ["power", "both"]:
+            print("\n" + "=" * 80)
+            print(f"POWER BEAMFORMER ({space})")
+            print("=" * 80)
 
-        out_files_power = save_beamformer_results(
-            cfg=cfg,
-            filters=filters,
-            stcs=stcs_power,
-            analysis_type="power",
-        )
+            stcs_power = run_beamformer_power(
+                epochs=data["epochs"],
+                filters=filters,
+                cfg=cfg,
+            )
 
-        add_to_report(
-            cfg=cfg,
-            stcs=out_files_power,
-            analysis_type="power",
-            src=data["forward"]["src"],
-        )
+            out_files_power = save_beamformer_results(
+                cfg=cfg,
+                filters=filters,
+                stcs=stcs_power,
+                analysis_type="power",
+                source_space=space,
+            )
+
+            add_to_report(
+                cfg=cfg,
+                stcs=out_files_power,
+                analysis_type="power",
+                src=forward["src"],
+                source_space=space,
+            )
 
     print("\n" + "=" * 80)
     print("BEAMFORMER ANALYSIS COMPLETE")

--- a/tests/test_beamformer_volume.py
+++ b/tests/test_beamformer_volume.py
@@ -24,6 +24,7 @@ from custom.run_beamformer import (
     add_to_report,
     build_volume_forward,
     load_beamformer_data,
+    resolve_source_spaces,
     save_beamformer_results,
 )
 
@@ -86,6 +87,42 @@ def _patch_common(stack_extra=None):
             return_value=((0.3,), "5120"),
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# resolve_source_spaces
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSourceSpaces:
+    def test_default_is_surface(self):
+        assert resolve_source_spaces(SimpleNamespace()) == ["surface"]
+
+    def test_single_string(self):
+        cfg = SimpleNamespace(_beamformer_source_space="volume")
+        assert resolve_source_spaces(cfg) == ["volume"]
+
+    def test_list_runs_both_in_order(self):
+        cfg = SimpleNamespace(_beamformer_source_space=["volume", "surface"])
+        assert resolve_source_spaces(cfg) == ["volume", "surface"]
+
+    def test_tuple_accepted(self):
+        cfg = SimpleNamespace(_beamformer_source_space=("surface", "volume"))
+        assert resolve_source_spaces(cfg) == ["surface", "volume"]
+
+    def test_duplicates_collapsed(self):
+        cfg = SimpleNamespace(_beamformer_source_space=["volume", "volume", "surface"])
+        assert resolve_source_spaces(cfg) == ["volume", "surface"]
+
+    def test_invalid_entry_raises(self):
+        cfg = SimpleNamespace(_beamformer_source_space=["surface", "banana"])
+        with pytest.raises(ValueError, match="_beamformer_source_space"):
+            resolve_source_spaces(cfg)
+
+    def test_empty_list_raises(self):
+        cfg = SimpleNamespace(_beamformer_source_space=[])
+        with pytest.raises(ValueError, match="must not be empty"):
+            resolve_source_spaces(cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +366,45 @@ class TestLoadBeamformerDataVolume:
         with pytest.raises(ValueError, match="_beamformer_source_space"):
             load_beamformer_data(vol_cfg)
 
+    def test_list_builds_both_forwards(self, vol_cfg):
+        """A list runs both: surface loaded from disk, volume built; both kept."""
+        vol_cfg._beamformer_source_space = ["surface", "volume"]
+        deriv = Path(vol_cfg.deriv_root)
+        meg_dir = deriv / "sub-001" / "ses-01" / "meg"
+        meg_dir.mkdir(parents=True)
+        fwd_path = meg_dir / "sub-001_ses-01_task-restingstate_fwd.fif"
+        epo_path = meg_dir / "sub-001_ses-01_task-restingstate_proc-clean_epo.fif"
+        fwd_path.touch()
+        epo_path.touch()
+
+        info = mne.create_info(["MEG001"], 300.0, ["mag"])
+        surf_fwd = MagicMock(spec=mne.Forward)
+        surf_fwd.__getitem__ = lambda self, k: [1, 2] if k == "src" else None
+        vol_fwd = MagicMock(spec=mne.Forward)
+        vol_fwd.__getitem__ = lambda self, k: [1] if k == "src" else None
+        mock_epochs = MagicMock(spec=mne.Epochs)
+        mock_epochs.__len__ = lambda self: 10
+        mock_epochs.ch_names = ["MEG001"]
+
+        with (
+            patch(
+                "custom.run_beamformer.mne.read_forward_solution",
+                return_value=surf_fwd,
+            ),
+            patch("custom.run_beamformer.mne.read_epochs", return_value=mock_epochs),
+            patch("custom.run_beamformer.mne.io.read_info", return_value=info),
+            patch(
+                "custom.run_beamformer.build_volume_forward", return_value=vol_fwd
+            ) as mock_build,
+        ):
+            data = load_beamformer_data(vol_cfg)
+
+        assert set(data["forwards"]) == {"surface", "volume"}
+        assert data["forwards"]["surface"] is surf_fwd
+        assert data["forwards"]["volume"] is vol_fwd
+        assert data["forward"] is surf_fwd  # first entry in the list
+        mock_build.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # save_beamformer_results — volume naming
@@ -363,6 +439,37 @@ class TestSaveBeamformerVolumeNaming:
             vol_cfg, filters=MagicMock(), stcs={"stim_a": stc}, analysis_type="time"
         )
         assert "+lcmv+hemi" in str(stc.save.call_args.args[0])
+
+    def test_explicit_source_space_param_overrides_cfg(self, vol_cfg):
+        """cfg says volume, but an explicit source_space='surface' wins."""
+        stc = MagicMock()
+        save_beamformer_results(
+            vol_cfg,
+            filters=MagicMock(),
+            stcs={"stim_a": stc},
+            analysis_type="time",
+            source_space="surface",
+        )
+        assert "+lcmv+hemi" in str(stc.save.call_args.args[0])
+
+    def test_volume_filter_gets_acq_vol_tag(self, vol_cfg):
+        """Volume filters are tagged acq-vol so a combined run doesn't collide."""
+        vol_cfg._beamformer_save_filters = True
+        filt = MagicMock()
+        save_beamformer_results(
+            vol_cfg, filters=filt, stcs={}, analysis_type="time", source_space="volume"
+        )
+        saved = str(filt.save.call_args.args[0])
+        assert "acq-vol" in saved and "lcmv" in saved
+
+    def test_surface_filter_has_no_acq_vol_tag(self, vol_cfg):
+        vol_cfg._beamformer_save_filters = True
+        filt = MagicMock()
+        save_beamformer_results(
+            vol_cfg, filters=filt, stcs={}, analysis_type="time", source_space="surface"
+        )
+        saved = str(filt.save.call_args.args[0])
+        assert "acq-vol" not in saved and "lcmv" in saved
 
 
 # ---------------------------------------------------------------------------
@@ -412,6 +519,36 @@ class TestAddToReportVolume:
         mock_stc.plot.assert_called_once()
         # src threaded through to the volume plot
         assert "src" in mock_stc.plot.call_args.kwargs
+
+    def test_source_space_param_selects_surface_path(self, vol_cfg):
+        """cfg default is volume, but source_space='surface' uses add_stc and a
+        space-namespaced title."""
+        vol_cfg._beamformer_add_to_report = True
+        vol_cfg.exec_params = MagicMock()
+        vol_cfg.report_stc_n_time_points = 51
+        mock_report = MagicMock()
+        stcs = {"stim_a": Path("/fake/sub-001_stim_a+lcmv+hemi")}
+
+        with (
+            patch("custom.run_beamformer.get_fs_subject", return_value="sub-001_ses-01"),
+            patch(
+                "custom.run_beamformer.get_fs_subjects_dir",
+                return_value="/fake/subjects_dir",
+            ),
+            patch(
+                "custom.run_beamformer._open_report",
+                return_value=self._report_cm(mock_report),
+            ),
+            patch("custom.run_beamformer._sanitize_cond_tag", side_effect=lambda c: c),
+        ):
+            add_to_report(
+                vol_cfg, stcs, analysis_type="time", src=MagicMock(),
+                source_space="surface",
+            )
+
+        mock_report.add_stc.assert_called_once()
+        mock_report.add_figure.assert_not_called()
+        assert "surface" in mock_report.add_stc.call_args.kwargs["title"]
 
     def test_volume_without_src_skips(self, vol_cfg, capsys):
         vol_cfg._beamformer_add_to_report = True


### PR DESCRIPTION
_beamformer_source_space now accepts a list/tuple (e.g. ["volume", "surface"]) to run both reconstructions in one invocation, in addition to a single string. main() loops over the resolved spaces, computing a forward, filters, STCs, and report entries for each; the data/noise covariance and rank are shared.

To keep the two from colliding: volume filters are saved with an `_acq-vol` tag (STCs already differ via +vol/-vl vs +hemi/-stc), and report titles/tags are namespaced by source space. save_beamformer_results and add_to_report take an explicit `source_space` argument (falling back to the first configured space for single-space back-compat); load_beamformer_data now returns data["forwards"] keyed by space (data["forward"] kept as the first).

Add resolve_source_spaces() (normalise/validate/de-duplicate), document the list option and update validation in docs/config-sample.py, and add tests.